### PR TITLE
Create basic skeleton of CLI

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -25,6 +25,60 @@
       <groupId>com.fwmotion</groupId>
       <artifactId>3scale-cms-rest-client</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-apache-httpclient</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-config-yaml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-container-image-jib</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-picocli</artifactId>
+    </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>${groupId.quarkus}</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>default-generate-code</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>generate-code</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>default-generate-code-tests</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>generate-code-tests</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>default-build</id>
+            <phase>package</phase>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/cli/src/main/java/com/fwmotion/threescale/cms/cli/CommandBase.java
+++ b/cli/src/main/java/com/fwmotion/threescale/cms/cli/CommandBase.java
@@ -1,0 +1,19 @@
+package com.fwmotion.threescale.cms.cli;
+
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    headerHeading = "%n",
+    synopsisHeading = "%n@|red,bold USAGE|@%n    ",
+    parameterListHeading = "%n@|red,bold PARAMETERS|@%n",
+    descriptionHeading = "%n@|red,bold DESCRIPTION|@%n    ",
+    optionListHeading = "%n@|red,bold OPTIONS|@%n",
+    synopsisSubcommandLabel = "[SUBCOMMAND]",
+    commandListHeading = "%n@|red,bold SUBCOMMANDS|@%n",
+    abbreviateSynopsis = true,
+    mixinStandardHelpOptions = true,
+    showDefaultValues = true,
+    usageHelpAutoWidth = true
+)
+public class CommandBase {
+}

--- a/cli/src/main/java/com/fwmotion/threescale/cms/cli/DeleteCommand.java
+++ b/cli/src/main/java/com/fwmotion/threescale/cms/cli/DeleteCommand.java
@@ -1,0 +1,73 @@
+package com.fwmotion.threescale.cms.cli;
+
+import com.fwmotion.threescale.cms.ThreescaleCmsClient;
+import com.redhat.threescale.rest.cms.ApiException;
+import jdk.internal.org.jline.utils.Log;
+import picocli.CommandLine;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(
+    header = "Delete 3scale CMS Content",
+    name = "delete",
+    description = "Delete all possible content in the specified CMS"
+)
+public class DeleteCommand extends CommandBase implements Callable<Integer> {
+
+    @CommandLine.ParentCommand
+    private TopLevelCommand topLevelCommand;
+
+    @CommandLine.Parameters(
+        index = "0",
+        arity = "0..*"
+    )
+    private List<String> filenames;
+
+    @CommandLine.Option(
+        names = "--yes-i-really-want-to-delete-the-entire-developer-portal",
+        hidden = true,
+        defaultValue = "false"
+    )
+    private boolean reallyDeleteEverything;
+
+    @Nonnull
+    @Override
+    public Integer call() throws Exception {
+        if (filenames == null || filenames.isEmpty()) {
+            return deleteAll();
+        } else {
+            return deleteBySystemName(filenames);
+        }
+    }
+
+    @Nonnull
+    private Integer deleteAll() throws Exception {
+        ThreescaleCmsClient client = topLevelCommand.getClient();
+
+        if (!reallyDeleteEverything) {
+            Log.warn("Potentially destructive command avoided; re-run the command with option `--yes-i-really-want-to-delete-the-entire-developer-portal` to continue anyway.");
+            return 0;
+        }
+
+        topLevelCommand.getCmsObjects()
+            .forEach(cmsObj -> {
+                try {
+                    client.delete(cmsObj);
+                } catch (ApiException e) {
+                    // TODO: Actually handle exceptions better
+                    throw new RuntimeException(e);
+                }
+            });
+
+        return 0;
+    }
+
+    @Nonnull
+    private Integer deleteBySystemName(@Nonnull List<String> filenames) throws Exception {
+        // TODO
+        throw new UnsupportedOperationException("Not implemented yet.");
+    }
+
+}

--- a/cli/src/main/java/com/fwmotion/threescale/cms/cli/DiffCommand.java
+++ b/cli/src/main/java/com/fwmotion/threescale/cms/cli/DiffCommand.java
@@ -1,0 +1,31 @@
+package com.fwmotion.threescale.cms.cli;
+
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(
+    header = "Diff 3scale CMS with Local Files",
+    name = "diff",
+    description = "Display the difference between CMS and local files"
+)
+public class DiffCommand extends CommandBase implements Callable<Integer> {
+
+    @CommandLine.ParentCommand
+    private TopLevelCommand topLevelCommand;
+
+    @Override
+    public Integer call() throws Exception {
+        // TODO
+        throw new UnsupportedOperationException("Not implemented yet.");
+    }
+
+    @CommandLine.Command(
+        name = "details"
+    )
+    public Integer infoDetails() {
+        // TODO
+        throw new UnsupportedOperationException("Not implemented yet.");
+    }
+
+}

--- a/cli/src/main/java/com/fwmotion/threescale/cms/cli/DownloadCommand.java
+++ b/cli/src/main/java/com/fwmotion/threescale/cms/cli/DownloadCommand.java
@@ -1,0 +1,23 @@
+package com.fwmotion.threescale.cms.cli;
+
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(
+    header = "Download 3scale CMS Content",
+    name = "download",
+    description = "Download all contents of the specified CMS to the local folder"
+)
+public class DownloadCommand extends CommandBase implements Callable<Integer> {
+
+    @CommandLine.ParentCommand
+    private TopLevelCommand topLevelCommand;
+
+    @Override
+    public Integer call() throws Exception {
+        // TODO
+        throw new UnsupportedOperationException("Not implemented yet.");
+    }
+
+}

--- a/cli/src/main/java/com/fwmotion/threescale/cms/cli/InfoCommand.java
+++ b/cli/src/main/java/com/fwmotion/threescale/cms/cli/InfoCommand.java
@@ -1,0 +1,49 @@
+package com.fwmotion.threescale.cms.cli;
+
+import com.fwmotion.threescale.cms.model.CmsLayout;
+import com.fwmotion.threescale.cms.model.CmsObject;
+import io.quarkus.logging.Log;
+import org.apache.http.client.utils.URIBuilder;
+import picocli.CommandLine;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(
+    header = "3scale CMS Information",
+    name = "info",
+    description = "Display information on 3scale CMS and local files"
+)
+public class InfoCommand extends CommandBase implements Callable<Integer> {
+
+    @CommandLine.ParentCommand
+    private TopLevelCommand topLevelCommand;
+
+    @Override
+    public Integer call() throws Exception {
+        URIBuilder uriBuilder = new URIBuilder(topLevelCommand.getProviderDomain());
+        String targetPath = (uriBuilder.getPath() + "/admin/api/cms")
+            .replaceAll("/+", "/");
+        String cmsUrl = uriBuilder.setPath(targetPath).toString();
+        Log.info("Contacting CMS at " + cmsUrl + " to get content list");
+
+        List<CmsObject> allObjects = topLevelCommand.getCmsObjects();
+        CmsLayout defaultLayout = topLevelCommand.getDefaultLayout();
+
+        Log.info("The layout '" + defaultLayout.getSystemName() + "' was selected as the default layout for uploading new pages");
+        Log.info(allObjects.size() + " content elements found in CMS");
+
+        // TODO: Find the number of implicit
+
+        return 0;
+    }
+
+    @CommandLine.Command(
+        name = "details"
+    )
+    public Integer infoDetails() {
+        // TODO
+        throw new UnsupportedOperationException("Not implemented yet.");
+    }
+
+}

--- a/cli/src/main/java/com/fwmotion/threescale/cms/cli/TopLevelCommand.java
+++ b/cli/src/main/java/com/fwmotion/threescale/cms/cli/TopLevelCommand.java
@@ -1,0 +1,98 @@
+package com.fwmotion.threescale.cms.cli;
+
+import com.fwmotion.threescale.cms.ThreescaleCmsClient;
+import com.fwmotion.threescale.cms.ThreescaleCmsClientFactory;
+import com.fwmotion.threescale.cms.model.CmsLayout;
+import com.fwmotion.threescale.cms.model.CmsObject;
+import io.quarkus.picocli.runtime.annotations.TopCommand;
+import org.apache.commons.lang3.StringUtils;
+import picocli.CommandLine;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@TopCommand
+@CommandLine.Command(
+    header = {"3scale Content Management System CLI Tool"},
+    name = "3scale-cms",
+    subcommands = {
+        DownloadCommand.class,
+        UploadCommand.class,
+        DeleteCommand.class,
+        InfoCommand.class,
+        DiffCommand.class
+    },
+    synopsisSubcommandLabel = "[SUBCOMMAND]",
+    commandListHeading = "%n@|red,bold SUBCOMMANDS|@%n"
+)
+public class TopLevelCommand extends CommandBase {
+
+    @CommandLine.Option(
+        names = {"-k", "--insecure"},
+        description = "Proceed with server connections that fail TLS certificate validation"
+    )
+    private boolean useInsecureConnections;
+
+    @CommandLine.Parameters(
+        index = "0",
+        paramLabel = "PROVIDER_KEY",
+        arity = "1",
+        description = "Provider Key for full control of the target tenant. This will be ignored if --access-token is specified."
+    )
+    private String providerKey;
+
+    @CommandLine.Parameters(
+        index = "1",
+        paramLabel = "PROVIDER_DOMAIN",
+        arity = "1",
+        description = "The base URL of the admin portal; for example: %n  https://3scale-admin.apps.example.com/"
+    )
+    private String providerDomain;
+
+    @CommandLine.Option(
+        names = {"-a", "--access-token"},
+        paramLabel = "ACCESS_TOKEN",
+        arity = "1",
+        description = "Use an access token instead of a provider key. The access token must be granted permissions to both Account Management API and the hidden Content Management API"
+    )
+    private String accessToken;
+
+    private ThreescaleCmsClientFactory factory;
+    private List<CmsObject> cmsObjects;
+
+    public String getProviderDomain() {
+        return providerDomain;
+    }
+
+    public ThreescaleCmsClient getClient() {
+        if (factory == null) {
+            factory = new ThreescaleCmsClientFactory();
+            factory.setBaseUrl(providerDomain);
+            if (StringUtils.isNotBlank(accessToken)) {
+                factory.setAccessToken(accessToken);
+            } else {
+                factory.setProviderKey(providerKey);
+            }
+            factory.setUseInsecureConnections(useInsecureConnections);
+        }
+
+        return factory.getThreescaleCmsClient();
+    }
+
+    public List<CmsObject> getCmsObjects() {
+        if (cmsObjects == null) {
+            cmsObjects = getClient().listAllCmsObjects();
+        }
+
+        return new ArrayList<>(cmsObjects);
+    }
+
+    public CmsLayout getDefaultLayout() {
+        return getCmsObjects().stream()
+            .filter(cmsObj -> cmsObj instanceof CmsLayout)
+            .findFirst()
+            .map(cmsObj -> (CmsLayout) cmsObj)
+            .orElseThrow(() -> new IllegalStateException("Couldn't find any layout to use as default"));
+    }
+
+}

--- a/cli/src/main/java/com/fwmotion/threescale/cms/cli/UploadCommand.java
+++ b/cli/src/main/java/com/fwmotion/threescale/cms/cli/UploadCommand.java
@@ -1,0 +1,38 @@
+package com.fwmotion.threescale.cms.cli;
+
+import picocli.CommandLine;
+
+import java.io.File;
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(
+    header = "Upload 3scale CMS Content",
+    name = "upload",
+    description = "Upload all content, specified file or all specified folder contents to CMS"
+)
+public class UploadCommand extends CommandBase implements Callable<Integer> {
+
+    @CommandLine.ParentCommand
+    private TopLevelCommand topLevelCommand;
+
+    @CommandLine.Parameters(
+        index = "0",
+        arity = "0..*"
+    )
+    private File file;
+
+    @CommandLine.Option(
+        names = {"--layout"},
+        arity = "1",
+        paramLabel = "layout_file_name",
+        description = "Specify layout for new (not updated) pages"
+    )
+    private String layoutFilename;
+
+    @Override
+    public Integer call() throws Exception {
+        // TODO
+        throw new UnsupportedOperationException("Not implemented yet.");
+    }
+
+}

--- a/cli/src/main/resources/application.yaml
+++ b/cli/src/main/resources/application.yaml
@@ -1,0 +1,20 @@
+quarkus:
+  banner:
+    enabled: false
+
+  log:
+    console:
+      format: '%s%e%n'
+    category:
+      'io.quarkus':
+        level: ERROR
+      'com.fwmotion.threscale.cms.cli':
+        level: TRACE
+    min-level: TRACE
+
+  native:
+    additional-build-args:
+    - --report-unsupported-elements-at-runtime
+    enable-http-url-handler: true
+    enable-https-url-handler: true
+

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -26,6 +26,8 @@
 
     <!-- Maven First-party Plugins -->
     <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
+    <version.maven-surefire-plugin>3.0.0-M6</version.maven-surefire-plugin>
+    <version.maven-failsafe-plugin>3.0.0-M6</version.maven-failsafe-plugin>
 
     <!-- Third-party Maven Plugins -->
     <version.dokka-maven-plugin>1.6.10</version.dokka-maven-plugin>
@@ -36,6 +38,7 @@
 
     <!-- Dependency Group IDs -->
     <groupId.swagger-parser>io.swagger.parser.v3</groupId.swagger-parser>
+    <groupId.quarkus>io.quarkus.platform</groupId.quarkus>
 
     <!-- Dependency Versions -->
     <version.apache-commons-codec>1.15</version.apache-commons-codec>
@@ -51,6 +54,7 @@
     <version.log4j>2.17.2</version.log4j>
     <version.mapstruct>1.5.3.Final</version.mapstruct>
     <version.mockito>4.4.0</version.mockito>
+    <version.quarkus>2.13.2.Final</version.quarkus>
     <version.slf4j>1.7.36</version.slf4j>
     <version.swagger-annotations>1.6.5</version.swagger-annotations>
     <version.swagger-parser>2.0.31</version.swagger-parser>
@@ -70,6 +74,15 @@
         <groupId>com.fwmotion</groupId>
         <artifactId>3scale-cms-rest-client</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <!-- Quarkus -->
+      <dependency>
+        <groupId>${groupId.quarkus}</groupId>
+        <artifactId>quarkus-bom</artifactId>
+        <version>${version.quarkus}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <!-- Other dependencies -->
@@ -165,6 +178,11 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>${groupId.quarkus}</groupId>
+          <artifactId>quarkus-maven-plugin</artifactId>
+          <version>${version.quarkus}</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${version.maven-compiler-plugin}</version>
@@ -192,40 +210,43 @@
     </pluginManagement>
   </build>
 
-  <!--
-  <repositories>
-    <repository>
-      <id>redhat-ga-repository</id>
-      <name>Red Hat General Availability repository (all)</name>
-      <url>https://maven.repository.redhat.com/ga/</url>
-      <layout>default</layout>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </snapshots>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>redhat-ga-repository</id>
-      <name>Red Hat General Availability repository (all)</name>
-      <url>https://maven.repository.redhat.com/ga/</url>
-      <layout>default</layout>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-  -->
+  <profiles>
+    <profile>
+      <id>native</id>
+      <activation>
+        <property>
+          <name>native</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${version.maven-failsafe-plugin}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <systemPropertyVariables>
+                    <native.image.path>${project.build.directory}/${project.artifactId}</native.image.path>
+                    <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    <!--suppress MavenModelInspection -->
+                    <maven.home>${maven.home}</maven.home>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
This pull request includes the basic project structure for the command-line interface. CLI was structured to follow a similar format to the previous ruby-based tool. A few additional options were included, such as the ability to use access token instead of provider key.

Most commands have no implementation to them yet. The `info` command has an incomplete implementation, and the `delete` command is untested so far.

Native-mode compilation has also not been tested

Closes #5 