### PR TITLE
Beginning of GH Actions workflow to build container image and push

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,71 @@
+name: Build and Publish
+
+on:
+  workflow_dispatch: { }
+  release:
+    types:
+    - created
+
+jobs:
+  build:
+    name: Build and Push to GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout 3scale CMS
+      uses: actions/checkout@v3
+
+    - name: Set Up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: 'maven'
+        settings-path: ${{ github.workspace }}
+        server-id: github
+
+    - name: Maven Build, Deploy, and Push Container Image
+      run: >-
+        ./mvnw
+        --settings ${{ github.workspace }}/settings.xml
+        --batch-mode
+        deploy
+        -Pnative
+        -Dquarkus.container-image.build=true
+        -Dquarkus.container-image.push=true
+        -Dquarkus.container-image.registry=ghcr.io
+        -Dquarkus.container-image.group=${{ github.repository_owner }}
+        -Dquarkus.container-image.name=${{ github.event.repository.name }}
+        -Dquarkus.container-image.tag=latest
+        -Dquarkus.container-image.username=${{ github.actor }}
+        -Dquarkus.container-image.password=${{ github.token }}
+        -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Delete Old Parent POMs from Maven Repository
+      uses: actions/delete-package-versions@v3
+      with:
+        package-name: 'com.fwmotion.3scale-cms-tools-parent'
+        min-versions-to-keep: 3
+
+    - name: Delete Old REST client JARs from Maven Repository
+      uses: actions/delete-package-versions@v3
+      with:
+        package-name: 'com.fwmotion.3scale-cms-rest-client'
+        min-versions-to-keep: 3
+
+    - name: Delete Old CLI JARs from Maven Repository
+      uses: actions/delete-package-versions@v3
+      with:
+        package-name: 'com.fwmotion.3scale-cms-tools-cli'
+        min-versions-to-keep: 3
+
+    - name: Delete Old Aggregate POMs from Maven Repository
+      uses: actions/delete-package-versions@v3
+      with:
+        package-name: 'com.fwmotion.3scale-cms-tools-aggregate'
+        min-versions-to-keep: 3

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # 3scale CMS Tools
 
-**TODO**: Rewrite this as needed
+**TODO**: Rewrite this as needed. Also add directory mount to podman command
+examples.
 
-**Note**: There are plans/work to implement an API for Portal CMS. Ref: https://issues.redhat.com/browse/THREESCALE-7244
+**Note**: There are plans/work to implement an API for Portal CMS.
+Ref: https://issues.redhat.com/browse/THREESCALE-7244
 
 ## DISCLAIMER
 
-It is important to know that these tools, as well as the 3scale REST API that they use, are undocumented and not supported by Red Hat. These CMS tools, as well as the underlying API, may change at any moment, without any guarantee of backwards compatibility. Therefore, we cannot recommend this tool for production use.
+It is important to know that these tools, as well as the 3scale REST API that
+they use, are undocumented and not supported by Red Hat. These CMS tools, as
+well as the underlying API, may change at any moment, without any guarantee
+of backwards compatibility. Therefore, we cannot recommend this tool for
+production use.
 
 ## Concepts
 
@@ -20,18 +26,27 @@ Section is a logical grouping, somewhat similar to a directory.
 
 ### Template
 
-Templates refer to textual content that will be served from the 3scale CMS. Templates may hold static content (such as scripts or stylesheets) or may
-be templated for server-side rendering as needed.
+Templates refer to textual content that will be served from the 3scale CMS.
+Templates may hold static content (such as scripts or stylesheets) or may be
+templated for server-side rendering as needed.
 
 ## Installation
 
-TODO
+Installation is performed using a container host, such as podman:
 
-## Overview
+```bash
+podman pull ghcr.io/fwmotion/3scale-cms
+```
 
-The `cms` command enables you to do offline editing, changes or version control of the contents of a CMS in your admin portal in 3scale.
+## Usage Overview
 
-In the CMS it is possible to create a file, a template or a section. Files are for example an image, a JS script or a CSS stylesheet. A template is generally content in `.html.liquid` file. A section is a hierarchical folder in the CMS for storing other elements.
+The `3scale-cms` command enables you to do offline editing, changes or
+version control of the contents of a CMS in your admin portal in 3scale.
+
+In the CMS it is possible to create a file, a template or a section. Files are
+for example an image, a JS script or a CSS stylesheet. A template is generally
+content in `.html.liquid` file. A section is a hierarchical folder in the CMS
+for storing other elements.
 
 ### Mirroring CMS contents locally
 
@@ -43,7 +58,7 @@ An exception occurs, as it is possible to create a file/template in the CMS that
 
 It is often desireable to have some files in the local directory that you do not want to upload to the CMS. Examples could be files used in the version control of your CMS contents (e.g. a `.git` folder), or files used in the testing or Continuous Integration of your contents (e.g. `travis.yml` file).
 
-To have the `cms` command ignore these files, they can be added to the `.cmsignore` file in the root directory of the CMS mirror. These files use the 'glob' format to allow specifying patterns of files and directories, not just specific files.
+To have the `3scale-cms` command ignore these files, they can be added to the `.cmsignore` file in the root directory of the CMS mirror. These files use the 'glob' format to allow specifying patterns of files and directories, not just specific files.
 
 ### New local page/layout files
 
@@ -64,12 +79,12 @@ If no layouts are available in the CMS, the tool will not run.
 If you wish to use a different layout for a newly created page, you currently have to go to the CMS in the admin portal
 and change it manually.
 
-## Using the `cms` command
+## Using the `3scale-cms` command
 
 ### Prerequisites
 
 You must have an account in 3scale. The CMS contents can be viewed in the **Developer Portal** section of the admin portal for that account.
-To use the `cms` command you need two pieces of information:
+To use the `3scale-cms` command you need two pieces of information:
 - Your **PROVIDER_KEY**. This can be found in the Account tab of your admin portal (only visible to the users with "admin" role).
 - The **PROVIDER_DOMAIN** of your admin portal. e.g. `https://mycompany-admin.3scale.net`
 
@@ -77,11 +92,13 @@ To use the `cms` command you need two pieces of information:
 
 The command should be invoked from the root directory of the folder where your local copy of the CMS will be made and worked on.
 
-Invoke the `cms` command with the following:
+Invoke the `3scale-cms` command with the following:
 
-    cms PROVIDER_KEY PROVIDER_DOMAIN <action> [parameter]
+```bash
+podman run --rm -it ghcr.io/fwmotion/3scale-cms PROVIDER_KEY PROVIDER_DOMAIN <action> [parameter]
+```
 
-The `cms` command has five actions:
+The `3scale-cms` command has five actions:
 - **info**      - show information about contents of the CMS and the local files. It accepts the optional parameter: 'details'
 - **diff**      - show the difference in contents between the CMS and the local files. It accepts the optional parameter: 'details'
 - **download**  - download all the contents of the CMS (no parameter). Or specify a file or section (with its contents) to download
@@ -93,20 +110,26 @@ Usage of each is explained below:
 ### cms info
 Show information about contents of the CMS and the local files. It accepts the optional parameter: 'details'
 
-    cms PROVIDER_KEY PROVIDER_DOMAIN info
+```bash
+podman run --rm -it ghcr.io/fwmotion/3scale-cms PROVIDER_KEY PROVIDER_DOMAIN info
+```
 
 Output should resemble:
 
-> Contacting CMS at PROVIDER_DOMAIN/admin/api/cms to get content list
-> The layout 'main_layout' was selected as the default layout for uploading new pages
-> 118 content elements found in CMS
-> 7 ignored local files (matching patterns in '.cmsignore')
-> 152 (non-ignored) local files
-> 4 local folders exist due to file/template system_names containing '/'
+```
+Contacting CMS at PROVIDER_DOMAIN/admin/api/cms to get content list
+The layout 'main_layout' was selected as the default layout for uploading new pages
+118 content elements found in CMS
+7 ignored local files (matching patterns in '.cmsignore')
+152 (non-ignored) local files
+4 local folders exist due to file/template system_names containing '/'
+```
 
 Use
 
-    cms PROVIDER_KEY PROVIDER_DOMAIN info details
+```bash
+podman run --rm -it ghcr.io/fwmotion/3scale-cms PROVIDER_KEY PROVIDER_DOMAIN info details
+```
 
 to get the list of specific files in each of those four categories:
 - CMS contents elements
@@ -114,47 +137,53 @@ to get the list of specific files in each of those four categories:
 - Local files that are not being ignored
 - List of folders created due to CMS elements with '/' in the name
 
-### cms diff
+### 3scale-cms diff
 Shows the differences in contents (taking into account ignored files and implicit folders) between the CMS and the local
 files.
 
 Use
 
-    cms PROVIDER_KEY PROVIDER_DOMAIN diff
+```bash
+podman run --rm -it ghcr.io/fwmotion/3scale-cms PROVIDER_KEY PROVIDER_DOMAIN diff
+```
 
 Output should resemble:
-> Contacting CMS at PROVIDER_DOMAIN/admin/api/cms to get content list
-> The layout 'main_layout' was selected as the default layout for uploading new pages
->
-> Summary:
-> 0 files to be created locally
-> 0 files to be updated locally
-> 17 files to be created on CMS
-> 1 files to be updated on CMS
+```
+Contacting CMS at PROVIDER_DOMAIN/admin/api/cms to get content list
+The layout 'main_layout' was selected as the default layout for uploading new pages
+
+Summary:
+0 files to be created locally
+0 files to be updated locally
+17 files to be created on CMS
+1 files to be updated on CMS
+```
 
 to get the list of specific files to be applied on 'download' and 'upload' use:
 
-    cms PROVIDER_KEY PROVIDER_DOMAIN diff details
+```bash
+podman run --rm -it ghcr.io/fwmotion/3scale-cms PROVIDER_KEY PROVIDER_DOMAIN diff details
+```
 
-### cms download
+### 3scale-cms download
 If used without an additional file/directory name parameter, this action downloads the entire contents of the CMS that either doesn't exist locally, or is out of date locally (based on timestamps of files/folders).
 
 If a filename is specified, then only that file is downloaded (if it exists in the CMS and is out of date locally).
 
 If a directory name is specified, then it and all its contents (recursively down) are checked and any content that is found to exist in the CMS and is out of date is downloaded.
 
-Files matching patterns in '.cmsignore' and skipped.
+Files matching patterns in `.cmsignore` and skipped.
 
-### cms upload
+### 3scale-cms upload
 If used without an additional file/directory name parameter, this action uploads all local files found under the current working directory that are either out of date in the CMS (based on timestamps) or do not exist in the CMS.
 
 If a filename is specified, then only that file is uploaded (if it exists in the CMS and is out of date, or does not exist in the CMS).
 
 If a directory name is specified, then it and all its contents (recursively down) are checked and any content that is found to not exist in the CMS or is out of date in the CMS is uploadd.
 
-Files matching patterns in '.cmsignore' and skipped.
+Files matching patterns in `.cmsignore` and skipped.
 
-### cms delete
+### 3scale-cms delete
 If used without an additional parameter this will attempt to delete all content under the 'root' section on the remote CMS (indicated via domain parameter).
 
 If used with a specific filename it will attempt to delete that entry int he remote CMS.
@@ -172,7 +201,7 @@ Create a directory where you will work on your CMS locally
     mkdir my_cms
     cd my_cms
 
-### Create your '.cmsignore' file
+### Create your `.cmsignore` file
 
     touch .cmsignore
 
@@ -180,8 +209,12 @@ You can edit this file at any time.
 
 ### Check the status
 
-    cms PROVIDER_KEY PROVIDER_DOMAIN info details
+```bash
+podman run --rm -it ghcr.io/fwmotion/3scale-cms PROVIDER_KEY PROVIDER_DOMAIN info details
+```
 
 ### Download the current contents of your CMS
 
-    cms PROVIDER_KEY PROVIDER_DOMAIN download
+```bash
+podman run --rm -it ghcr.io/fwmotion/3scale-cms PROVIDER_KEY PROVIDER_DOMAIN download
+```

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -18,6 +18,9 @@
 
   <name>3scale CMS Tools (command-line interface)</name>
   <description><![CDATA[
+    A Quarkus-based command-line interface to the 3scale Content Management
+    System. It is recommended to use this via the native-mode compiled
+    container image `ghcr.io/fwmotion/3scale-cms`.
   ]]></description>
 
   <dependencies>
@@ -53,6 +56,7 @@
       <plugin>
         <groupId>${groupId.quarkus}</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
+        <version>${version.quarkus}</version>
         <extensions>true</extensions>
         <executions>
           <execution>

--- a/cli/src/main/java/com/fwmotion/threescale/cms/cli/TopLevelCommand.java
+++ b/cli/src/main/java/com/fwmotion/threescale/cms/cli/TopLevelCommand.java
@@ -15,21 +15,25 @@ import java.util.List;
 @CommandLine.Command(
     header = {"3scale Content Management System CLI Tool"},
     name = "3scale-cms",
+    description = "Tool for interacting with 3scale's Content Management " +
+        "System for managing content and templates that will be used to " +
+        "render a tenant's Developer Portal",
     subcommands = {
+        InfoCommand.class,
+        DiffCommand.class,
         DownloadCommand.class,
         UploadCommand.class,
         DeleteCommand.class,
-        InfoCommand.class,
-        DiffCommand.class
     },
-    synopsisSubcommandLabel = "[SUBCOMMAND]",
-    commandListHeading = "%n@|red,bold SUBCOMMANDS|@%n"
+    synopsisSubcommandLabel = "[COMMAND] ",
+    commandListHeading = "%n@|red,bold COMMANDS|@%n"
 )
 public class TopLevelCommand extends CommandBase {
 
     @CommandLine.Option(
         names = {"-k", "--insecure"},
-        description = "Proceed with server connections that fail TLS certificate validation"
+        description = "Proceed with server connections that fail TLS " +
+            "certificate validation"
     )
     private boolean useInsecureConnections;
 
@@ -37,7 +41,8 @@ public class TopLevelCommand extends CommandBase {
         index = "0",
         paramLabel = "PROVIDER_KEY",
         arity = "1",
-        description = "Provider Key for full control of the target tenant. This will be ignored if --access-token is specified."
+        description = "Provider Key for full control of the target tenant. " +
+            "This will be ignored if --access-token is specified."
     )
     private String providerKey;
 
@@ -45,7 +50,8 @@ public class TopLevelCommand extends CommandBase {
         index = "1",
         paramLabel = "PROVIDER_DOMAIN",
         arity = "1",
-        description = "The base URL of the admin portal; for example: %n  https://3scale-admin.apps.example.com/"
+        description = "The base URL of the admin portal; for example: %n" +
+            "  https://3scale-admin.apps.example.com/"
     )
     private String providerDomain;
 
@@ -53,7 +59,9 @@ public class TopLevelCommand extends CommandBase {
         names = {"-a", "--access-token"},
         paramLabel = "ACCESS_TOKEN",
         arity = "1",
-        description = "Use an access token instead of a provider key. The access token must be granted permissions to both Account Management API and the hidden Content Management API"
+        description = "Use an access token instead of a provider key. The " +
+            "access token must be granted permissions to both " +
+            "Account Management API and the hidden Content Management API"
     )
     private String accessToken;
 

--- a/cli/src/main/jib/cms/.cmsignore
+++ b/cli/src/main/jib/cms/.cmsignore
@@ -1,0 +1,1 @@
+# Default .cmsignore file; also as a placeholder to keep /cms directory

--- a/cli/src/main/resources/application.yaml
+++ b/cli/src/main/resources/application.yaml
@@ -15,6 +15,7 @@ quarkus:
   native:
     additional-build-args:
     - --report-unsupported-elements-at-runtime
+    - --initialize-at-run-time=com.redhat.threescale.rest.cms.Configuration
     enable-http-url-handler: true
     enable-https-url-handler: true
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -13,7 +13,7 @@
 
   <name>3scale CMS Tools (parent)</name>
   <description><![CDATA[
-    Project to provide common base configuration for inheritance by other
+    Maven project to provide common base configuration for inheritance by other
     related projects
   ]]></description>
 
@@ -25,6 +25,9 @@
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.release>11</maven.compiler.release>
 
+    <!-- Support Quarkus knowing about multi-module project -->
+    <quarkus.bootstrap.workspace-discovery>true</quarkus.bootstrap.workspace-discovery>
+
     <!-- Maven First-party Plugins -->
     <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
     <version.maven-surefire-plugin>3.0.0-M6</version.maven-surefire-plugin>
@@ -33,7 +36,10 @@
     <!-- Third-party Maven Plugins -->
     <version.dokka-maven-plugin>1.6.10</version.dokka-maven-plugin>
     <version.jacoco-maven-plugin>0.8.7</version.jacoco-maven-plugin>
-    <version.openapi-generator-maven-plugin>6.2.0</version.openapi-generator-maven-plugin>
+    <version.jandex-maven-plugin>1.2.3</version.jandex-maven-plugin>
+    <version.openapi-generator-maven-plugin>
+      6.2.0
+    </version.openapi-generator-maven-plugin>
     <version.pitest-maven>1.7.5</version.pitest-maven>
     <version.pitest-junit5-plugin>0.15</version.pitest-junit5-plugin>
 
@@ -47,15 +53,14 @@
     <version.apache-commons-io>2.11.0</version.apache-commons-io>
     <version.apache-commons-lang>3.12.0</version.apache-commons-lang>
     <version.apache-httpclient>4.5.13</version.apache-httpclient>
-    <version.jackson>2.13.4</version.jackson>
-    <version.jackson-databind>2.14.0-rc1</version.jackson-databind>
+    <version.jackson>2.14.0-rc2</version.jackson>
     <version.jakarta-annotation>1.3.5</version.jakarta-annotation>
     <version.jsr305>3.0.2</version.jsr305>
     <version.junit>5.8.2</version.junit>
     <version.log4j>2.17.2</version.log4j>
     <version.mapstruct>1.5.3.Final</version.mapstruct>
     <version.mockito>4.4.0</version.mockito>
-    <version.quarkus>2.13.2.Final</version.quarkus>
+    <version.quarkus>2.12.3.Final</version.quarkus>
     <version.slf4j>1.7.36</version.slf4j>
     <version.swagger-annotations>1.6.5</version.swagger-annotations>
     <version.swagger-parser>2.0.31</version.swagger-parser>
@@ -104,18 +109,18 @@
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>${version.jackson}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
         <version>${version.jackson}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${version.jackson}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${version.jackson-databind}</version>
+        <version>${version.jackson}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -203,6 +208,20 @@
           </configuration>
         </plugin>
         <plugin>
+          <groupId>org.jboss.jandex</groupId>
+          <artifactId>jandex-maven-plugin</artifactId>
+          <version>${version.jandex-maven-plugin}</version>
+          <executions>
+            <execution>
+              <id>default-jandex</id>
+              <phase>package</phase>
+              <goals>
+                <goal>jandex</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <groupId>org.openapitools</groupId>
           <artifactId>openapi-generator-maven-plugin</artifactId>
           <version>${version.openapi-generator-maven-plugin}</version>
@@ -233,8 +252,12 @@
                 </goals>
                 <configuration>
                   <systemPropertyVariables>
-                    <native.image.path>${project.build.directory}/${project.artifactId}</native.image.path>
-                    <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    <native.image.path>
+                      ${project.build.directory}/${project.artifactId}
+                    </native.image.path>
+                    <java.util.logging.manager>
+                      org.jboss.logmanager.LogManager
+                    </java.util.logging.manager>
                     <!--suppress MavenModelInspection -->
                     <maven.home>${maven.home}</maven.home>
                   </systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,9 @@
 
   <name>3scale CMS Tools (aggregate)</name>
   <description><![CDATA[
-    Project to group multiple submodules related to 3scale's Content Management System API, and
-    to handle build ordering and aggregate test reporting
+    Maven project to group multiple submodules related to 3scale's Content
+    Management System API, and to handle build ordering and aggregate test
+    reporting
   ]]></description>
 
   <modules>

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -18,6 +18,10 @@
 
   <name>3scale CMS Tools (REST client library)</name>
   <description><![CDATA[
+    Java library to interact with 3scale Content Management System via the
+    CMS's REST API. This requires use of either a Provider Key or an
+    Access Token that has been granted permission to the Account Management
+    API and the hidden Content Management API
   ]]></description>
 
   <dependencies>
@@ -103,6 +107,10 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.jboss.jandex</groupId>
+        <artifactId>jandex-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
         <executions>
@@ -153,9 +161,14 @@
                 <serializationLibrary>jackson</serializationLibrary>
 
                 <!-- Configure packages -->
-                <invokerPackage>com.redhat.threescale.rest.cms</invokerPackage>
-                <apiPackage>com.redhat.threescale.rest.cms.api</apiPackage>
-                <modelPackage>com.redhat.threescale.rest.cms.model
+                <invokerPackage>
+                  com.redhat.threescale.rest.cms
+                </invokerPackage>
+                <apiPackage>
+                  com.redhat.threescale.rest.cms.api
+                </apiPackage>
+                <modelPackage>
+                  com.redhat.threescale.rest.cms.model
                 </modelPackage>
 
                 <!--
@@ -173,9 +186,11 @@
                 <!-- Other options -->
                 <openApiNullable>false</openApiNullable>
                 <hideGenerationTimestamp>true</hideGenerationTimestamp>
-                <disallowAdditionalPropertiesIfNotPresent>false
+                <disallowAdditionalPropertiesIfNotPresent>
+                  false
                 </disallowAdditionalPropertiesIfNotPresent>
-                <sortModelPropertiesByRequiredFlag>false
+                <sortModelPropertiesByRequiredFlag>
+                  false
                 </sortModelPropertiesByRequiredFlag>
               </configOptions>
             </configuration>


### PR DESCRIPTION
This pull request adds a Git Hub Actions workflow that will build a container image and push it to Git Hub Packages (ghcr.io). It will also deploy Maven artifacts into Git Hub Packages as well.

* Bump maven wrapper to Maven 3.8.6
* Add a small bit of description to CLI commands
* Add directive to initialize REST client Configuration class at runtime to facilitate native build
* Drop to Quarkus v2.12 since v2.13 seems to introduce bug in reading multi-module Maven projects