### PR TITLE
Improve `delete` command of CLI; few other tweaks

### DIFF
--- a/cli/src/main/java/com/fwmotion/threescale/cms/cli/DeleteCommand.java
+++ b/cli/src/main/java/com/fwmotion/threescale/cms/cli/DeleteCommand.java
@@ -2,99 +2,191 @@ package com.fwmotion.threescale.cms.cli;
 
 import com.fwmotion.threescale.cms.ThreescaleCmsClient;
 import com.fwmotion.threescale.cms.cli.support.CmsObjectPathKeyGenerator;
-import com.redhat.threescale.rest.cms.ApiException;
+import com.fwmotion.threescale.cms.cli.support.CmsSectionToTopComparator;
+import com.fwmotion.threescale.cms.cli.support.PathRecursionSupport;
+import com.fwmotion.threescale.cms.model.CmsObject;
 import io.quarkus.logging.Log;
 import picocli.CommandLine;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
-import java.util.Collection;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 @CommandLine.Command(
     header = "Delete 3scale CMS Content",
     name = "delete",
-    description = "Delete all possible content in the specified CMS"
+    description = "Delete all content, specified file, or all specified " +
+        "folder contents in the 3scale CMS"
 )
 public class DeleteCommand extends CommandBase implements Callable<Integer> {
 
+    private static final String REALLY_DELETE_FLAG = "--yes-i-really-want-to-delete-the-entire-developer-portal";
+
     @Inject
-    CmsObjectPathKeyGenerator cmsObjectPathKeyGenerator;
+    CmsObjectPathKeyGenerator pathKeyGenerator;
+
+    @Inject
+    PathRecursionSupport pathRecursionSupport;
+
+    @Inject
+    CmsSectionToTopComparator sectionToTopComparator;
+
+    @CommandLine.ArgGroup
+    MutuallyExclusiveGroup exclusiveOptions;
 
     @CommandLine.ParentCommand
     private TopLevelCommand topLevelCommand;
-
-    @CommandLine.Parameters(
-        index = "0",
-        arity = "0..*",
-        paramLabel = "PATH",
-        description = "Paths in developer portal to be deleted. If omitted, " +
-            "all CMS objects will be deleted from the 3scale tenant."
-    )
-    private List<String> paths;
-
     @CommandLine.Option(
-        names = "--yes-i-really-want-to-delete-the-entire-developer-portal",
-        hidden = true,
-        defaultValue = "false"
+        names = {"-n", "--dry-run"},
+        description = "Dry run: do not delete any files; instead, just list " +
+            "operations that would be performed"
     )
-    private boolean reallyDeleteEverything;
+    private boolean noop;
 
     @Nonnull
     @Override
     public Integer call() throws Exception {
-        if (paths == null || paths.isEmpty()) {
-            return deleteAll();
+
+        List<String> remotePathsToDelete;
+        PathRecursionSupport.RecursionOption recursionStyle;
+
+        if (isDeleteAll()) {
+            if (!noop
+                && !isReallyDeleteEverything()) {
+                Log.error("Potentially destructive command avoided; re-run the command with option `" + REALLY_DELETE_FLAG + "` to continue anyway.");
+                return 1;
+            }
+
+            remotePathsToDelete = Collections.singletonList("/");
+            recursionStyle = PathRecursionSupport.RecursionOption.PATH_PREFIX;
         } else {
-            return deleteByPath(paths);
+            remotePathsToDelete = exclusiveOptions.individualFilesDeletionGroup.paths;
+            recursionStyle = recursionStyle();
+
+            if (remotePathsToDelete.contains("/")
+                && recursionStyle != PathRecursionSupport.RecursionOption.NONE) {
+
+                Log.error("Root path specified for deletion with recursion; re-run command with no paths specified to delete all contents");
+                return 1;
+            }
         }
-    }
 
-    @Nonnull
-    private Integer deleteAll() throws Exception {
-        ThreescaleCmsClient client = topLevelCommand.getClient();
+        Map<String, CmsObject> remoteObjectsByPath = topLevelCommand.getCmsObjects()
+            .stream()
+            .collect(Collectors.toMap(pathKeyGenerator::generatePathKeyForObject, o -> o));
 
-        if (!reallyDeleteEverything) {
-            Log.warn("Potentially destructive command avoided; re-run the command with option `--yes-i-really-want-to-delete-the-entire-developer-portal` to continue anyway.");
+        List<CmsObject> remoteObjectsToDelete = pathRecursionSupport.calculateSpecifiedPaths(
+                remotePathsToDelete,
+                recursionStyle,
+                remoteObjectsByPath)
+            .stream()
+            .map(remoteObjectsByPath::get)
+            .sorted(sectionToTopComparator
+                .thenComparing(CmsObject::getId)
+                .reversed())
+            .collect(Collectors.toList());
+
+        if (remoteObjectsToDelete.isEmpty()) {
+            Log.info("Nothing to do.");
             return 0;
         }
 
-        topLevelCommand.getCmsObjects()
-            .forEach(cmsObj -> {
-                try {
-                    client.delete(cmsObj);
-                } catch (ApiException e) {
-                    // TODO: Actually handle exceptions better
-                    throw new RuntimeException(e);
-                }
-            });
+        if (noop) {
+            for (CmsObject object : remoteObjectsToDelete) {
+                Log.info("Would delete " + object.getType() + " " + pathKeyGenerator.generatePathKeyForObject(object));
+            }
+        } else {
+            ThreescaleCmsClient client = topLevelCommand.getClient();
+
+            deleteObjects(client, pathKeyGenerator, remoteObjectsToDelete);
+        }
 
         return 0;
     }
 
-    @Nonnull
-    private Integer deleteByPath(@Nonnull Collection<String> filenames) throws Exception {
-        ThreescaleCmsClient client = topLevelCommand.getClient();
-        Set<String> remainingFilenames = new HashSet<>(filenames);
+    static void deleteObjects(ThreescaleCmsClient client, CmsObjectPathKeyGenerator pathKeyGenerator, List<CmsObject> remoteObjectsToDelete) {
+        for (CmsObject object : remoteObjectsToDelete) {
+            String objectName = object.getType() + " " + pathKeyGenerator.generatePathKeyForObject(object);
 
-        topLevelCommand.getCmsObjects().stream()
-            .filter(cmsObject -> remainingFilenames.remove(cmsObjectPathKeyGenerator.generatePathKeyForObject(cmsObject)))
-            .forEach(cmsObj -> {
-                try {
-                    // TODO: Remove sub-objects of sections that are specified
-                    client.delete(cmsObj);
-                } catch (ApiException e) {
-                    // TODO: Actually handle exceptions better
-                    throw new RuntimeException(e);
-                }
-            });
+            Log.info("Deleting " + objectName);
+            try {
+                client.delete(object);
+            } catch (Exception e) {
+                // TODO: Handle exceptions properly, and provide better logs
+                //       indicating the reason for failure
+                Log.warn("Failed to delete " + objectName, e);
+            }
+        }
+    }
 
-        Log.warn("Paths not removed: " + String.join(", ", remainingFilenames));
+    private boolean isDeleteAll() {
+        return exclusiveOptions == null
+            || exclusiveOptions.individualFilesDeletionGroup == null
+            || exclusiveOptions.individualFilesDeletionGroup.paths == null
+            || exclusiveOptions.individualFilesDeletionGroup.paths.isEmpty();
+    }
 
-        return 0;
+    private boolean isReallyDeleteEverything() {
+        return exclusiveOptions != null
+            && exclusiveOptions.allFilesDeletionGroup != null
+            && exclusiveOptions.allFilesDeletionGroup.reallyDeleteEverything;
+    }
+
+    private PathRecursionSupport.RecursionOption recursionStyle() {
+        return Optional.ofNullable(exclusiveOptions)
+            .map(options -> options.individualFilesDeletionGroup)
+            .map(individualFilesDeletionGroup -> individualFilesDeletionGroup.recurseBy)
+            .orElse(PathRecursionSupport.RecursionOption.PATH_PREFIX);
+    }
+
+    private static class MutuallyExclusiveGroup {
+
+        @CommandLine.ArgGroup(exclusive = false)
+        AllFilesDeletionGroup allFilesDeletionGroup;
+
+        @CommandLine.ArgGroup(exclusive = false)
+        IndividualFilesDeletionGroup individualFilesDeletionGroup;
+
+    }
+
+    private static class AllFilesDeletionGroup {
+
+        @CommandLine.Option(
+            names = REALLY_DELETE_FLAG,
+            hidden = true,
+            defaultValue = "false"
+        )
+        boolean reallyDeleteEverything;
+
+    }
+
+    private static class IndividualFilesDeletionGroup {
+
+        @CommandLine.Option(
+            names = {"-r", "--recurse-by"},
+            description = {
+                "Method of recursing CMS objects when a section is specified " +
+                    "in PATH_KEY",
+                "Options: PARENT_ID, PATH_PREFIX, NONE"
+            },
+            defaultValue = "PATH_PREFIX"
+        )
+        PathRecursionSupport.RecursionOption recurseBy;
+
+        @CommandLine.Parameters(
+            index = "0",
+            arity = "0..*",
+            paramLabel = "PATH_KEY",
+            description = "Paths in developer portal to be deleted. If omitted, " +
+                "all CMS objects will be deleted from the 3scale tenant."
+        )
+        List<String> paths;
+
     }
 
 }

--- a/cli/src/main/java/com/fwmotion/threescale/cms/cli/DownloadCommand.java
+++ b/cli/src/main/java/com/fwmotion/threescale/cms/cli/DownloadCommand.java
@@ -54,7 +54,7 @@ public class DownloadCommand extends CommandBase implements Callable<Integer> {
     @CommandLine.Option(
         names = {"-n", "--dry-run"},
         description = "Dry run: do not download any files; instead, just list " +
-            "what operations would be performed"
+            "operations that would be performed"
     )
     private boolean noop;
 
@@ -151,34 +151,6 @@ public class DownloadCommand extends CommandBase implements Callable<Integer> {
         return 0;
     }
 
-    private boolean isDownloadAll() {
-        return exclusiveOptions == null
-            || exclusiveOptions.individualFilesDownloadGroup == null
-            || exclusiveOptions.individualFilesDownloadGroup.downloadPaths == null
-            || exclusiveOptions.individualFilesDownloadGroup.downloadPaths.isEmpty();
-    }
-
-    private boolean isIncludeUnchanged() {
-        return Optional.ofNullable(exclusiveOptions)
-            .map(options -> options.allFilesDownloadGroup)
-            .map(allFilesDownloadGroup -> allFilesDownloadGroup.includeUnchanged)
-            .orElse(false);
-    }
-
-    private boolean isDeleteMissing() {
-        return Optional.ofNullable(exclusiveOptions)
-            .map(options -> options.allFilesDownloadGroup)
-            .map(allFilesDownloadGroup -> allFilesDownloadGroup.deleteMissing)
-            .orElse(false);
-    }
-
-    private PathRecursionSupport.RecursionOption recursionStyle() {
-        return Optional.ofNullable(exclusiveOptions)
-            .map(options -> options.individualFilesDownloadGroup)
-            .map(individualFilesDownloadGroup -> individualFilesDownloadGroup.recurseBy)
-            .orElse(PathRecursionSupport.RecursionOption.PATH_PREFIX);
-    }
-
     private void performDownload(@Nonnull CmsObject cmsObject,
                                  @Nonnull Path targetPath) throws IOException {
         String draftIndicator;
@@ -254,6 +226,34 @@ public class DownloadCommand extends CommandBase implements Callable<Integer> {
         FileUtils.copyInputStreamToFile(fileContent, targetFile);
     }
 
+    private boolean isDownloadAll() {
+        return exclusiveOptions == null
+            || exclusiveOptions.individualFilesDownloadGroup == null
+            || exclusiveOptions.individualFilesDownloadGroup.downloadPaths == null
+            || exclusiveOptions.individualFilesDownloadGroup.downloadPaths.isEmpty();
+    }
+
+    private boolean isIncludeUnchanged() {
+        return Optional.ofNullable(exclusiveOptions)
+            .map(options -> options.allFilesDownloadGroup)
+            .map(allFilesDownloadGroup -> allFilesDownloadGroup.includeUnchanged)
+            .orElse(false);
+    }
+
+    private boolean isDeleteMissing() {
+        return Optional.ofNullable(exclusiveOptions)
+            .map(options -> options.allFilesDownloadGroup)
+            .map(allFilesDownloadGroup -> allFilesDownloadGroup.deleteMissing)
+            .orElse(false);
+    }
+
+    private PathRecursionSupport.RecursionOption recursionStyle() {
+        return Optional.ofNullable(exclusiveOptions)
+            .map(options -> options.individualFilesDownloadGroup)
+            .map(individualFilesDownloadGroup -> individualFilesDownloadGroup.recurseBy)
+            .orElse(PathRecursionSupport.RecursionOption.PATH_PREFIX);
+    }
+
     private static class MutuallyExclusiveGroup {
 
         @CommandLine.ArgGroup(exclusive = false)
@@ -295,7 +295,7 @@ public class DownloadCommand extends CommandBase implements Callable<Integer> {
             names = {"-r", "--recurse-by"},
             description = {
                 "Method of recursing CMS objects when a section is specified " +
-                    "in PATH",
+                    "in PATH_KEY",
                 "Options: PARENT_ID, PATH_PREFIX, NONE"
             },
             defaultValue = "PATH_PREFIX"
@@ -303,7 +303,7 @@ public class DownloadCommand extends CommandBase implements Callable<Integer> {
         PathRecursionSupport.RecursionOption recurseBy;
 
         @CommandLine.Parameters(
-            paramLabel = "PATH",
+            paramLabel = "PATH_KEY",
             arity = "1..*",
             description = {
                 "Paths to download from 3scale CMS to local files",

--- a/cli/src/main/java/com/fwmotion/threescale/cms/cli/InfoCommand.java
+++ b/cli/src/main/java/com/fwmotion/threescale/cms/cli/InfoCommand.java
@@ -56,14 +56,14 @@ public class InfoCommand extends CommandBase implements Callable<Integer> {
         displayDefaultLayout(topLevelCommand.getDefaultLayout(),
             cmsObjectPathKeyGenerator.generatePathKeyForObject(topLevelCommand.getDefaultLayout()));
 
-        List<CmsObject> allObjects = topLevelCommand.getCmsObjects();
+        List<CmsObject> allRemoteObjects = topLevelCommand.getCmsObjects();
         LocalRemoteTreeComparisonDetails details = treeComparator.compareLocalAndRemoteCmsObjectTrees(
-            allObjects.stream(),
+            allRemoteObjects.stream(),
             topLevelCommand.getRootDirectory()
         );
 
-        Log.info(allObjects.size() + " items found in CMS");
-        if (includeDetails) {
+        Log.info(allRemoteObjects.size() + " items found in CMS");
+        if (includeDetails && !allRemoteObjects.isEmpty()) {
             int longestPath = details.getRemoteObjectsByCmsPath().keySet().stream()
                 .mapToInt(String::length)
                 .max()
@@ -77,20 +77,21 @@ public class InfoCommand extends CommandBase implements Callable<Integer> {
                     .map(pair -> "\t'" + StringUtils.rightPad(pair.getKey() + "'", longestPath + 1)
                         + " "
                         + pair.getValue().getType())
-                    .collect(Collectors.joining("\n"))
-                    + "\n");
+                    .collect(Collectors.joining("\n")));
         }
+        Log.info("");
 
         Log.info(details.getLocalPathsIgnored().size()
             + " ignored local files (matching patterns in '.cmsignore')");
-        if (includeDetails) {
+        if (includeDetails && !details.getLocalPathsIgnored().isEmpty()) {
             Log.info(
                 listPaths(details.getLocalPathsIgnored().stream()));
         }
+        Log.info("");
 
         Log.info(details.getLocalObjectsByCmsPath().size()
             + " (non-ignored) local files");
-        if (includeDetails) {
+        if (includeDetails && !details.getLocalObjectsByCmsPath().isEmpty()) {
             int longestPath = details.getLocalObjectsByCmsPath().keySet().stream()
                 .mapToInt(String::length)
                 .max()
@@ -104,16 +105,18 @@ public class InfoCommand extends CommandBase implements Callable<Integer> {
                     .map(pair -> "\t'" + StringUtils.rightPad(pair.getKey() + "'", longestPath + 1)
                         + " "
                         + pair.getValue().getLeft().getType())
-                    .collect(Collectors.joining("\n"))
-                    + "\n");
+                    .collect(Collectors.joining("\n")));
         }
+        Log.info("");
 
         Log.info(details.getImplicitSectionPaths().size()
             + " implicit folders due to file/template system_names containing '/'");
-        if (includeDetails) {
+        if (includeDetails && !details.getImplicitSectionPaths().isEmpty()) {
             Log.info(
                 listPaths(details.getImplicitSectionPaths().stream()));
         }
+        Log.info("");
+
     }
 
     static void displayCmsUrl(String providerDomain) throws URISyntaxException {
@@ -145,8 +148,7 @@ public class InfoCommand extends CommandBase implements Callable<Integer> {
             .sequential()
             .sorted(InfoCommand::comparePaths)
             .map(path -> "\t'" + path + "'")
-            .collect(Collectors.joining("\n"))
-            + "\n";
+            .collect(Collectors.joining("\n"));
     }
 
     static int comparePaths(@Nonnull String leftString,

--- a/cli/src/main/java/com/fwmotion/threescale/cms/cli/support/CmsSectionToTopComparator.java
+++ b/cli/src/main/java/com/fwmotion/threescale/cms/cli/support/CmsSectionToTopComparator.java
@@ -1,0 +1,28 @@
+package com.fwmotion.threescale.cms.cli.support;
+
+import com.fwmotion.threescale.cms.model.CmsObject;
+import com.fwmotion.threescale.cms.model.ThreescaleObjectType;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.util.Comparator;
+
+@ApplicationScoped
+public class CmsSectionToTopComparator implements Comparator<CmsObject> {
+
+    @Override
+    public int compare(CmsObject left, CmsObject right) {
+        boolean leftIsSection = left.getType() == ThreescaleObjectType.SECTION;
+        boolean rightIsSection = right.getType() == ThreescaleObjectType.SECTION;
+        if (leftIsSection) {
+            if (rightIsSection) {
+                return 0;
+            }
+            return -1;
+        } else if (rightIsSection) {
+            return 1;
+        }
+
+        return 0;
+    }
+
+}

--- a/cli/src/main/java/com/fwmotion/threescale/cms/cli/support/LocalRemoteObjectTreeComparator.java
+++ b/cli/src/main/java/com/fwmotion/threescale/cms/cli/support/LocalRemoteObjectTreeComparator.java
@@ -91,6 +91,7 @@ public class LocalRemoteObjectTreeComparator {
             Set.of(FileVisitOption.FOLLOW_LINKS),
             Integer.MAX_VALUE,
             new LocalFileVisitor(localFileCmsObjectGenerator,
+                cmsObjectPathKeyGenerator,
                 rootPath,
                 implicitSectionPaths,
                 localPathIgnored::add,

--- a/cli/src/main/java/com/fwmotion/threescale/cms/cli/support/PathRecursionSupport.java
+++ b/cli/src/main/java/com/fwmotion/threescale/cms/cli/support/PathRecursionSupport.java
@@ -1,9 +1,6 @@
 package com.fwmotion.threescale.cms.cli.support;
 
-import com.fwmotion.threescale.cms.model.CmsFile;
-import com.fwmotion.threescale.cms.model.CmsObject;
-import com.fwmotion.threescale.cms.model.CmsSection;
-import com.fwmotion.threescale.cms.model.ThreescaleObjectType;
+import com.fwmotion.threescale.cms.model.*;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -20,9 +17,10 @@ public class PathRecursionSupport {
 
     private static final Map<Class<? extends CmsObject>, Function<? super CmsObject, Integer>> GET_PARENT_ID_FUNCTIONS =
         Map.of(
-            // TODO: See if there's a way to get section ID / parent ID from
-            //       other object types
+            // TODO: Find a way to get section ID / parent ID from other object
+            //       types
             CmsFile.class, file -> ((CmsFile) file).getSectionId(),
+            CmsPage.class, page -> ((CmsPage) page).getSectionId(),
             CmsSection.class, section -> ((CmsSection) section).getParentId()
         );
 

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/ThreescaleCmsClientImpl.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/ThreescaleCmsClientImpl.java
@@ -111,7 +111,9 @@ public class ThreescaleCmsClientImpl implements ThreescaleCmsClient {
         // When there's no draft content, the "draft" should be the same as
         // the "published" content
         if (result.isEmpty()) {
-            return getTemplatePublished(templateId);
+            result = Optional.ofNullable(template.getPublished())
+                .map(StringUtils::trimToNull)
+                .map(input -> IOUtils.toInputStream(input, Charset.defaultCharset()));
         }
 
         return result;


### PR DESCRIPTION
* Implement delete recursion
* Reverse order of deletion so that child objects will be deleted first
* Don't double-get template details from 3scale when retrieving draft content
* Determine pathkey from local objects' generated CmsObject, to hopefully standardize the few different ways CmsLayout objects might be represented
* Don't double-print empty lines when 0 objects are listed from `info` command

Closes #17 