### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This closes #39 by adding the dependabot config for updating maven packages. I've tested it locally and it was creating the correct pull requests. 

Happy Hacktoberfest!