### PR TITLE
#41 Add new GitHub Actions workflow to submit dependency tree samples

### DIFF
--- a/.github/workflows/submit-dependency-tree-samples.yml
+++ b/.github/workflows/submit-dependency-tree-samples.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Java
         uses: actions/setup-java@v3
@@ -25,5 +25,3 @@ jobs:
 
       - name: Submit Dependency Snapshot
         uses: advanced-security/maven-dependency-submission-action@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/submit-dependency-tree-samples.yml
+++ b/.github/workflows/submit-dependency-tree-samples.yml
@@ -1,0 +1,29 @@
+name: Submit Dependency Tree Samples
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/pom.xml'
+
+jobs:
+  submit-dependency-tree:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Submit Dependency Snapshot
+        uses: advanced-security/maven-dependency-submission-action@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow that updates the dependency graph whenever there's a change to pom.xml in the main branch