### PR TITLE
Enhance GitHub Actions workflow for performing releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,30 @@
 version: 2
 updates:
-  - package-ecosystem: "maven"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
+      interval: weekly
+    commit-message:
+      prefix: '[github-actions] '
+      prefix-development: '[github-actions] '
+      include: scope
+    reviewers:
+      - rmgrimm
+    labels:
+      - build
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: '[maven] '
+      prefix-development: '[maven] '
+      include: scope
+    reviewers:
+      - rmgrimm
+    labels:
+      - build
+      - dependencies
+    open-pull-requests-limit: 5

--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -1,0 +1,128 @@
+name: Build Container Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        description: Git Ref
+        required: true
+        type: string
+      build-mode:
+        description: Build Mode
+        required: false
+        type: choice
+        default: only_jvm
+        options:
+          - only_jvm
+          - only_native
+          - jvm_and_native
+      tag-as-latest:
+        description: Tag as Latest
+        required: false
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      git-ref:
+        required: true
+        type: string
+      build-mode:
+        required: false
+        type: string
+        default: only_jvm
+      tag-as-latest:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  container-image:
+    name: Build, Tag, Push Container Image
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git-ref }}
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: '17'
+          settings-path: ${{ github.workspace }}
+          server-id: github
+
+      - name: Determine Home Directory
+        id: find-home
+        run: |
+          echo "home=$HOME" >> $GITHUB_OUTPUT
+
+      - name: Cache Maven Local Repo
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.find-home.outputs.home }}/.m2/repository
+          key: ${{ runner.os }}-${{ runner.arch }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-maven-
+
+      - name: Lowercase Repository Owner
+        id: repo-owner-string
+        uses: ASzc/change-string-case-action@v5
+        with:
+          string: ${{ github.repository_owner }}
+
+      - name: Lowercase Repository Name
+        id: repo-name-string
+        uses: ASzc/change-string-case-action@v5
+        with:
+          string: ${{ github.event.repository.name }}
+
+      - name: Build and Push Image (JVM-mode)
+        if: ${{ success() && contains(fromJSON('["only_jvm","jvm_and_native"]'), inputs.build-mode) }}
+        run: >-
+          ./mvnw
+          --settings ${{ github.workspace }}/settings.xml
+          --batch-mode
+          verify
+          -Dquarkus.jib.platforms=linux/amd64,linux/arm64
+          -Dquarkus.container-image.build=true
+          -Dquarkus.container-image.push=true
+          -Dquarkus.container-image.registry=ghcr.io
+          -Dquarkus.container-image.username=${{ github.actor }}
+          -Dquarkus.container-image.password=${{ github.token }}
+          -Dquarkus.container-image.group=${{ steps.repo-owner-string.outputs.lowercase }}
+          -Dquarkus.container-image.name=${{ steps.repo-name-string.outputs.lowercase }}
+          -Dquarkus.container-image.tag=${{ inputs.git-ref }}
+          ${{ inputs.tag-as-latest == true && '-Dquarkus.container-image.additional-tags=latest' || '' }}
+          -Dquarkus.container-image.labels.\"org.opencontainers.image.source\"=${{ github.server_url }}/${{ github.repository }}
+          -Dquarkus.container-image.labels.url=${{ github.server_url }}/${{ github.repository }}/tree/${{ inputs.git-ref }}
+          -Dquarkus.container-image.labels.vcs-type=git
+          -Dquarkus.container-image.labels.vcs-ref=${{ inputs.git-ref }}
+
+      - name: Build and Push Image (native-mode)
+        if: ${{ success() && contains(fromJSON('["only_native","jvm_and_native"]'), inputs.build-mode) }}
+        run: >-
+          ./mvnw
+          --settings ${{ github.workspace }}/settings.xml
+          --batch-mode
+          verify
+          -Pnative
+          -Dquarkus.container-image.build=true
+          -Dquarkus.container-image.push=true
+          -Dquarkus.container-image.registry=ghcr.io
+          -Dquarkus.container-image.username=${{ github.actor }}
+          -Dquarkus.container-image.password=${{ github.token }}
+          -Dquarkus.container-image.group=${{ steps.repo-owner-string.outputs.lowercase }}
+          -Dquarkus.container-image.name=${{ steps.repo-name-string.outputs.lowercase }}
+          -Dquarkus.container-image.tag=${{ inputs.git-ref }}-native
+          ${{ inputs.tag-as-latest == true && '-Dquarkus.container-image.additional-tags=latest-native' || '' }}
+          -Dquarkus.container-image.labels.\"org.opencontainers.image.source\"=${{ github.server_url }}/${{ github.repository }}
+          -Dquarkus.container-image.labels.url=${{ github.server_url }}/${{ github.repository }}/tree/${{ inputs.git-ref }}
+          -Dquarkus.container-image.labels.vcs-type=git
+          -Dquarkus.container-image.labels.vcs-ref=${{ inputs.git-ref }}

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -1,31 +1,59 @@
 name: Perform Release
 
 on:
-  workflow_dispatch: { }
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Dry Run
+        required: false
+        type: boolean
+        default: false
+      release-version:
+        description: Release Version
+        required: false
+        type: string
+      next-version:
+        description: Next Development Version
+        required: false
+        type: string
 
 jobs:
-  build-deploy-maven:
+  maven-build-deploy:
     name: Build and Deploy Maven Artifacts
     runs-on: ubuntu-latest
+
     permissions:
       contents: write
       packages: write
 
     outputs:
       release-sha: ${{ steps.release-sha.outputs.value }}
+      release-tag: ${{ steps.release-tag.outputs.value }}
 
     steps:
     - name: Checkout 3scale CMS
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set Up JDK
       uses: actions/setup-java@v3
       with:
         distribution: temurin
         java-version: '17'
-        cache: maven
         settings-path: ${{ github.workspace }}
         server-id: github
+
+    - name: Determine Home Directory
+      id: find-home
+      run: |
+        echo "home=$HOME" >> $GITHUB_OUTPUT
+
+    - name: Cache Maven Local Repo
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.find-home.outputs.home }}/.m2/repository
+        key: ${{ runner.os }}-${{ runner.arch }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-maven-
 
     - name: Configure Git User
       run: |
@@ -41,12 +69,20 @@ jobs:
         -e 's;<developerConnection>.*</developerConnection>;<developerConnection>scm:git:${{ github.server_url }}/${{ github.repository }}.git</developerConnection>;'
         pom.xml
 
-    - name: Prepare Maven Release (build code)
+    - name: Prepare Maven Release (build code and create tag)
+      id: release-prepare
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        NEXT_VERSION_ARGS: ${{ inputs.next-version && format('-DdevelopmentVersion={0}', inputs.next-version) || '' }}
+        RELEASE_VER_ARGS: ${{ inputs.release-version && format('-DreleaseVersion={0}', inputs.release-version) || '' }}
       run: >-
         ./mvnw
         --settings ${{ github.workspace }}/settings.xml
         --batch-mode
         release:prepare
+        ${{ format('-DdryRun={0}', inputs.dry-run) }}
+        $NEXT_VERSION_ARGS
+        $RELEASE_VER_ARGS
         -DcheckModificationExcludeList=pom.xml
         -Dusername=${{ github.token }}
         -DpreparationGoals='clean verify'
@@ -54,79 +90,86 @@ jobs:
         --settings ${{ github.workspace }}/settings.xml
         -DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}
         '
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
 
     - name: Perform Maven Release (deploy artifacts)
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: >-
         ./mvnw
         --settings ${{ github.workspace }}/settings.xml
         --batch-mode
         release:perform
+        -DlocalCheckout=true
+        ${{ format('-DdryRun={0}', inputs.dry-run) }}
         -Dusername=${{ github.token }}
         -Dgoals='deploy'
+
+    - name: Rollback Maven Release unless Success
+      if: ${{ !success() && !inputs.dry-run && steps.release-prepare.outcome == 'success' }}
       env:
         GITHUB_TOKEN: ${{ github.token }}
-
-    - name: Determine release commit SHA
-      id: release-sha
-      run: |
-        echo "value=$(git rev-parse HEAD^)" >> $GITHUB_OUTPUT
-
-  container-image:
-    name: Build, Tag, Push Container Image
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-
-    needs:
-    - build-deploy-maven
-
-    steps:
-    - name: Checkout 3scale CMS
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ needs.build-deploy-maven.outputs.release-sha }}
-
-    - name: Set Up JDK
-      uses: actions/setup-java@v3
-      with:
-        distribution: temurin
-        java-version: '17'
-        cache: maven
-        settings-path: ${{ github.workspace }}
-        server-id: github
-
-    - name: Calculate lowercase repository owner
-      id: repo-owner-string
-      uses: ASzc/change-string-case-action@v5
-      with:
-        string: ${{ github.repository_owner }}
-
-    - name: Calculate lowercase repository name
-      id: repo-name-string
-      uses: ASzc/change-string-case-action@v5
-      with:
-        string: ${{ github.event.repository.name }}
-
-    - name: Build and push CLI container image
       run: >-
         ./mvnw
         --settings ${{ github.workspace }}/settings.xml
         --batch-mode
-        verify
-        --projects cli
-        --also-make
-        -Dquarkus.jib.platforms=linux/amd64,linux/arm64
-        -Dquarkus.container-image.build=true
-        -Dquarkus.container-image.push=true
-        -Dquarkus.container-image.registry=ghcr.io
-        -Dquarkus.container-image.username=${{ github.actor }}
-        -Dquarkus.container-image.password=${{ github.token }}
-        -Dquarkus.container-image.group=${{ steps.repo-owner-string.outputs.lowercase }}
-        -Dquarkus.container-image.name=${{ steps.repo-name-string.outputs.lowercase }}
-        -Dquarkus.container-image.additional-tags=latest
-        -Dquarkus.container-image.labels.name=${{ steps.repo-owner-string.outputs.lowercase }}/${{ steps.repo-name-string.outputs.lowercase }}
-        -Dquarkus.container-image.labels.url=${{ github.server_url }}/${{ github.repository }}/tree/${{ needs.build-deploy-maven.outputs.release-sha }}
-        -Dquarkus.container-image.labels.vcs-type=git
-        -Dquarkus.container-image.labels.vcs-ref=${{ needs.build-deploy-maven.outputs.release-sha }}
+        release:rollback
+        -Dusername=${{ github.token }}
+
+    - name: Determine Release Commit SHA
+      id: release-sha
+      run: |
+        echo "value=$(git rev-parse HEAD^)" >> $GITHUB_OUTPUT
+
+    - name: Determine Release Tag
+      id: release-tag
+      env:
+        RELEASE_SHA: ${{ steps.release-sha.outputs.value }}
+      run: |
+        echo "value=$(git show-ref --tags --dereference | grep -F $RELEASE_SHA | cut -d' ' -f2 | cut -d'^' -f1 | cut -d'/' -f3-)" >> $GITHUB_OUTPUT
+
+  create-github-release:
+    name: Create GitHub Release from Tag
+    runs-on: ubuntu-latest
+
+    if: ${{ success() && !inputs.dry-run }}
+
+    permissions:
+      contents: write
+
+    needs:
+      - maven-build-deploy
+
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.maven-build-deploy.outputs.release-tag }}
+
+      - uses: spenserblack/actions-tag-to-release@v3
+        with:
+          tag: ${{ needs.maven-build-deploy.outputs.release-tag }}
+          tag-as-title: true
+          draft: true
+          dry-run: ${{ inputs.dry-run }}
+          prerelease: auto
+          prerelease-pattern: v*.*.*-*
+
+  build-container-image:
+    name: Build, Tag, Push Container Image
+
+    if: ${{ success() && !inputs.dry-run }}
+
+    permissions:
+      contents: read
+      packages: write
+
+    secrets: inherit
+
+    needs:
+      - maven-build-deploy
+
+    uses: ./.github/workflows/build-container-image.yml
+    with:
+      git-ref: ${{ needs.maven-build-deploy.outputs.release-tag }}
+      build-mode: jvm_and_native
+      tag-as-latest: true

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -11,9 +11,18 @@ on:
       - unlocked
     branches:
       - main
+    paths-ignore:
+      - '.github/**'
+      - '.run/**'
+      - 'samples/**'
+      - .editorconfig
+      - .gitignore
+      - LICENSE
+      - README.adoc
 
 jobs:
-  build:
+  build-and-test:
+    name: Build and Run Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -23,10 +32,9 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
+          distribution: temurin
           java-version: '17'
-          distribution: 'temurin'
 
-      - name: Build and Verify
+      - name: Run Maven Build and Verify
         run: |
-          ./mvnw clean verify
-
+          ./mvnw --batch-mode clean verify

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -25,6 +25,9 @@ jobs:
     name: Build and Run Tests
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -35,6 +38,22 @@ jobs:
           distribution: temurin
           java-version: '17'
 
-      - name: Run Maven Build and Verify
+      - name: Determine Home Directory
+        id: find-home
         run: |
-          ./mvnw --batch-mode clean verify
+          echo "home=$HOME" >> $GITHUB_OUTPUT
+
+      - name: Cache Maven Local Repo
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.find-home.outputs.home }}/.m2/repository
+          key: ${{ runner.os }}-${{ runner.arch }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-maven-
+
+      - name: Run Maven Build and Verify
+        run: >-
+          ./mvnw
+          --batch-mode
+          clean
+          verify

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -55,14 +55,22 @@
     </quarkus.bootstrap.workspace-discovery>
 
     <!-- Maven First-party Plugins -->
+    <version.maven-artifact-plugin>3.5.0</version.maven-artifact-plugin>
+    <version.maven-clean-plugin>3.3.1</version.maven-clean-plugin>
     <version.maven-compiler-plugin>3.11.0</version.maven-compiler-plugin>
+    <version.maven-deploy-plugin>3.1.1</version.maven-deploy-plugin>
     <version.maven-enforcer-plugin>3.3.0</version.maven-enforcer-plugin>
     <version.maven-failsafe-plugin>3.1.2</version.maven-failsafe-plugin>
+    <version.maven-install-plugin>3.1.1</version.maven-install-plugin>
     <version.maven-jar-plugin>3.3.0</version.maven-jar-plugin>
-    <version.maven-surefire-plugin>3.1.2</version.maven-surefire-plugin>
     <version.maven-release-plugin>3.0.1</version.maven-release-plugin>
+    <version.maven-resources-plugin>3.3.1</version.maven-resources-plugin>
+    <version.maven-site-plugin>4.0.0-M9</version.maven-site-plugin>
+    <version.maven-surefire-plugin>3.1.2</version.maven-surefire-plugin>
+    <version.maven-wrapper-plugin>3.2.0</version.maven-wrapper-plugin>
 
     <!-- Third-party Maven Plugins -->
+    <version.depgraph-maven-plugin>4.0.2</version.depgraph-maven-plugin>
     <version.dokka-maven-plugin>1.6.10</version.dokka-maven-plugin>
     <version.find-and-replace-maven-plugin>
       1.1.0
@@ -146,6 +154,11 @@
         <artifactId>dec</artifactId>
         <version>${version.brotli-dec}</version>
       </dependency>
+      <dependency>
+        <groupId>org.mapstruct</groupId>
+        <artifactId>mapstruct</artifactId>
+        <version>${version.mapstruct}</version>
+      </dependency>
 
       <!-- Test Dependencies -->
       <dependency>
@@ -184,11 +197,6 @@
         <version>${version.hamcrest}</version>
         <scope>test</scope>
       </dependency>
-      <dependency>
-        <groupId>org.mapstruct</groupId>
-        <artifactId>mapstruct</artifactId>
-        <version>${version.mapstruct}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -199,6 +207,11 @@
           <groupId>${groupId.quarkus}</groupId>
           <artifactId>quarkus-maven-plugin</artifactId>
           <version>${version.quarkus}</version>
+        </plugin>
+        <plugin>
+          <groupId>com.github.ferstl</groupId>
+          <artifactId>depgraph-maven-plugin</artifactId>
+          <version>${version.depgraph-maven-plugin}</version>
         </plugin>
         <plugin>
           <groupId>io.github.floverfelt</groupId>
@@ -221,6 +234,16 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-artifact-plugin</artifactId>
+          <version>${version.maven-artifact-plugin}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>${version.maven-clean-plugin}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${version.maven-compiler-plugin}</version>
           <configuration>
@@ -237,6 +260,11 @@
               <compilerArg>-Amapstruct.unmappedTargetPolicy=ERROR</compilerArg>
             </compilerArgs>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>${version.maven-deploy-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -292,6 +320,11 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>${version.maven-install-plugin}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>${version.maven-jar-plugin}</version>
         </plugin>
@@ -302,6 +335,16 @@
           <configuration>
             <tagNameFormat>v@{project.version}</tagNameFormat>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>${version.maven-resources-plugin}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>${version.maven-site-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -323,6 +366,11 @@
               </configuration>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-wrapper-plugin</artifactId>
+          <version>${version.maven-wrapper-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>


### PR DESCRIPTION
- Allow specifying release version and next development version
- Allow dry-runs
- Create draft release in GitHub from the tag created by maven-release-plugin
- Split the container image building to a separate workflow
- Also add GitHub Actions to dependabot.yml
- Also add caching and path filtering to pull-request-tests.yml