### PR TITLE
Set up maven remote repository filtering

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -71,6 +71,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-maven-
 
+      - name: Set Up Maven Repo Filters
+        run: |
+          mkdir -p ${{ steps.find-home.outputs.home }}/.m2/repository/.remoteRepositoryFilters/
+          cp -av ${{ github.workspace }}/.mvn/filters/*.txt ${{ steps.find-home.outputs.home }}/.m2/repository/.remoteRepositoryFilters/
+
       - name: Lowercase Repository Owner
         id: repo-owner-string
         uses: ASzc/change-string-case-action@v5

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -55,6 +55,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-maven-
 
+    - name: Set Up Maven Repo Filters
+      run: |
+        mkdir -p ${{ steps.find-home.outputs.home }}/.m2/repository/.remoteRepositoryFilters/
+        cp -av ${{ github.workspace }}/.mvn/filters/*.txt ${{ steps.find-home.outputs.home }}/.m2/repository/.remoteRepositoryFilters/
+
     - name: Configure Git User
       run: |
         git config user.name "GitHub Actions"

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -51,6 +51,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-maven-
 
+      - name: Set Up Maven Repo Filters
+        run: |
+          mkdir -p ${{ steps.find-home.outputs.home }}/.m2/repository/.remoteRepositoryFilters/
+          cp -av ${{ github.workspace }}/.mvn/filters/*.txt ${{ steps.find-home.outputs.home }}/.m2/repository/.remoteRepositoryFilters/
+
       - name: Run Maven Build and Verify
         run: >-
           ./mvnw

--- a/.github/workflows/submit-dependency-tree-samples.yml
+++ b/.github/workflows/submit-dependency-tree-samples.yml
@@ -23,5 +23,23 @@ jobs:
           distribution: temurin
           java-version: '17'
 
+      - name: Determine Home Directory
+        id: find-home
+        run: |
+          echo "home=$HOME" >> $GITHUB_OUTPUT
+
+      - name: Cache Maven Local Repo
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.find-home.outputs.home }}/.m2/repository
+          key: ${{ runner.os }}-${{ runner.arch }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-maven-
+
+      - name: Set Up Maven Repo Filters
+        run: |
+          mkdir -p ${{ steps.find-home.outputs.home }}/.m2/repository/.remoteRepositoryFilters/
+          cp -av ${{ github.workspace }}/.mvn/filters/*.txt ${{ steps.find-home.outputs.home }}/.m2/repository/.remoteRepositoryFilters/
+
       - name: Submit Dependency Snapshot
         uses: advanced-security/maven-dependency-submission-action@v3

--- a/.mvn/filters/groupId-imposter.txt
+++ b/.mvn/filters/groupId-imposter.txt
@@ -1,0 +1,1 @@
+io.gatehill.imposter

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Daether.remoteRepositoryFilter.groupId=true


### PR DESCRIPTION
This will avoid looking for all the dependencies inside the `imposter` repository.