### PR TITLE
Fix uploads; add exception classes; other fixes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,9 @@
 = 3scale CMS Tools
-
+:sectnums:
 :toc:
 
 == Overview
+
 The 3scale CMS tools project provides the ability to interact with 3scale's
 Content Management System programmatically. The project also
 demonstrates API-first code generation.
@@ -24,21 +25,24 @@ This repository provides the following artifacts:
 
 === Command-Line Interface
 
-The 3scale CMS tools project provides a CLI tool that provides a convenient
-mechanism for interacting with the 3scale Content Management API. It is
-implemented using link:https://quarkus.io[Quarkus] and
+The 3scale CMS tools project includes a Command-Line Interface (CLI) tool that
+provides a convenient mechanism for interacting with the 3scale Developer Portal
+API. It is implemented using link:https://quarkus.io[Quarkus] and
 link:https://picocli.info[picocli].
+
+More information on CLI Usage may be found in the
+link:docs/cli-usage.adoc[Command-Line Interface Usage] document.
 
 === Container Images
 
 Images are available for running the command-line interface in container
 environments. Images are available in the GitHub Packages repository at
-link:https://github.com/orgs/FwMotion/packages?repo_name=3scale-cms[ghcr.io/fwmotion/3scale-cms].
+link:https://github.com/FwMotion/3scale-cms/pkgs/container/3scale-cms[ghcr.io/fwmotion/3scale-cms].
 
 The following image tags are used:
 
-* **VERSION** _(eg, 1.0.0)_: Execution of the CLI using the JVM
-* **VERSION-native** _(eg, 1.0.0-native)_: Execution of a native-built CLI
+* **VERSION** _(eg, v2.0.1)_: Execution of the CLI using the JVM
+* **VERSION-native** _(eg, v2.0.1-native)_: Execution of a native-built CLI
 * **latest**: The latest version available using JVM-mode builds
 * **latest-native**: The latest version available using native-mode builds
 
@@ -83,12 +87,13 @@ the available endpoints for managing CMS objects, along with the "provider"
 endpoint of the Account Management API. This provider endpoint is used for
 lookup of the Developer Portal base URL and the Developer Portal access code.
 
-=== REST Client JAR
+=== REST Client JARs
 
-The 3scale CMS tools project provides a standalone REST client JAR. The JAR is
-available in the GitHub Packages maven repository.
+The 3scale CMS tools project provides JARs to handle interaction with 3scale's
+Developer Portal API. These JARs are available in the GitHub Packages maven
+repository.
 
-To use the JAR in a Maven project, first include the following repository
+To use a JAR in a Maven project, first include the following repository
 definition:
 
 [source,xml]
@@ -110,8 +115,8 @@ definition:
 </repositories>
 ----
 
-To include the client JAR as a dependency, use the following dependency
-definition:
+As an example, to include the REST client JAR as a dependency, use the following
+dependency definition:
 
 [source,xml]
 ----

--- a/cli/src/main/java/com/fwmotion/threescale/cms/cli/DeleteCommand.java
+++ b/cli/src/main/java/com/fwmotion/threescale/cms/cli/DeleteCommand.java
@@ -4,6 +4,7 @@ import com.fwmotion.threescale.cms.ThreescaleCmsClient;
 import com.fwmotion.threescale.cms.cli.support.CmsObjectPathKeyGenerator;
 import com.fwmotion.threescale.cms.cli.support.CmsSectionToTopComparator;
 import com.fwmotion.threescale.cms.cli.support.PathRecursionSupport;
+import com.fwmotion.threescale.cms.exception.ThreescaleCmsCannotDeleteBuiltinException;
 import com.fwmotion.threescale.cms.model.CmsObject;
 import io.quarkus.logging.Log;
 import jakarta.annotation.Nonnull;
@@ -115,6 +116,8 @@ public class DeleteCommand extends CommandBase implements Callable<Integer> {
             Log.info("Deleting " + objectName);
             try {
                 client.delete(object);
+            } catch (ThreescaleCmsCannotDeleteBuiltinException e) {
+                Log.info("Could not delete built-in " + objectName);
             } catch (Exception e) {
                 // TODO: Handle exceptions properly, and provide better logs
                 //       indicating the reason for failure

--- a/cli/src/main/java/com/fwmotion/threescale/cms/cli/config/ReflectionConfiguration.java
+++ b/cli/src/main/java/com/fwmotion/threescale/cms/cli/config/ReflectionConfiguration.java
@@ -1,6 +1,7 @@
 package com.fwmotion.threescale.cms.cli.config;
 
 import com.fwmotion.threescale.cms.mixins.EnumHandlerMixIn;
+import com.redhat.threescale.rest.cms.model.Error;
 import com.redhat.threescale.rest.cms.model.*;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
@@ -12,7 +13,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
     BuiltinPartial.class,
     EnumHandler.class,
     EnumTemplateType.class,
-    ErrorHash.class,
+    Error.class,
     FileCreationRequest.class,
     FileList.class,
     FileUpdatableFields.class,

--- a/cli/src/main/java/com/fwmotion/threescale/cms/cli/support/LocalFileVisitor.java
+++ b/cli/src/main/java/com/fwmotion/threescale/cms/cli/support/LocalFileVisitor.java
@@ -62,7 +62,8 @@ class LocalFileVisitor extends SimpleFileVisitor<Path> {
         // If directory is not ignored, try loading .cmsignore
         Path cmsIgnorePath = dir.resolve(CMSIGNORE_FILENAME);
         if (cmsIgnorePath.toFile().exists()
-            && cmsIgnorePath.toFile().canRead()) {
+            && cmsIgnorePath.toFile().canRead()
+        ) {
             readCmsIgnoreFile(cmsIgnorePath);
         } else {
             ignoreRules.addLast(Collections.emptyList());
@@ -136,11 +137,10 @@ class LocalFileVisitor extends SimpleFileVisitor<Path> {
         Path normalizedPath = path.normalize();
 
         List<Boolean> matchingRules = ignoreRules.stream()
-            .sequential()
             .flatMap(Collection::stream)
             .filter(matcherEntry -> matcherEntry.getLeft().matches(normalizedPath))
             .map(Pair::getRight)
-            .collect(Collectors.toList());
+            .toList();
 
         if (matchingRules.isEmpty()) {
             // Nothing matched, so not ignored

--- a/docs/cli-usage.adoc
+++ b/docs/cli-usage.adoc
@@ -11,7 +11,7 @@ To use the `3scale-cms` command you need to provide a few parameters:
 
 - An **ACCESS_TOKEN**, which can be used instead of a PROVIDER_KEY. The access
 token must be granted permissions to both the Account Management API and the
-Content Management API.
+Developer Portal API.
 - The **PROVIDER_KEY**, which can be found in the Account tab of your admin
 portal (only visible to the users with "admin" role). The PROVIDER_KEY will be
 ignored if an ACCESS_TOKEN is specified.

--- a/docs/concepts.adoc
+++ b/docs/concepts.adoc
@@ -3,7 +3,7 @@
 :sectnums:
 :toc:
 
-== 3scale Content Management API Concepts
+== 3scale Developer Portal API Concepts
 
 The 3scale Developer Portal consists of 3 primary types of objects:
 

--- a/rest-client/pom.xml
+++ b/rest-client/pom.xml
@@ -278,7 +278,7 @@
                 or docs
               -->
               <generateModels>true</generateModels>
-              <generateModelTests>false</generateModelTests>
+              <generateModelTests>true</generateModelTests>
               <generateModelDocumentation>false</generateModelDocumentation>
 
               <generateSupportingFiles>true</generateSupportingFiles>

--- a/rest-client/src/main/dokka/module.md
+++ b/rest-client/src/main/dokka/module.md
@@ -1,3 +1,3 @@
 # Module 3scale-cms-rest-client
 
-A Java library for interacting with the 3scale Content Management API
+A Java library for interacting with the 3scale Developer Portal API

--- a/rest-client/src/main/dokka/packages.md
+++ b/rest-client/src/main/dokka/packages.md
@@ -11,7 +11,7 @@ developer-friendly model objects and auto-generated REST client objects
 # Package com.fwmotion.threescale.cms.mixins
 
 Support files to instruct Jackson on handling of JSON data when interacting
-with the 3scale Content Management API
+with the 3scale Developer Portal API
 
 # Package com.fwmotion.threescale.cms.model
 

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/ThreescaleCmsClient.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/ThreescaleCmsClient.java
@@ -1,22 +1,22 @@
 package com.fwmotion.threescale.cms;
 
+import com.fwmotion.threescale.cms.exception.ThreescaleCmsCannotDeleteBuiltinException;
+import com.fwmotion.threescale.cms.exception.ThreescaleCmsException;
 import com.fwmotion.threescale.cms.model.*;
-import com.redhat.threescale.rest.cms.ApiException;
 import jakarta.annotation.Nonnull;
 
 import java.io.File;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public interface ThreescaleCmsClient {
 
-    // TODO: Replace all "throws ApiException" with better exception handling
-
     @Nonnull
-    default Stream<CmsObject> streamAllCmsObjects() {
+    default Stream<CmsObject> streamAllCmsObjects() throws ThreescaleCmsException {
         return Stream.of(
             streamSections(),
             streamFiles(),
@@ -25,7 +25,7 @@ public interface ThreescaleCmsClient {
     }
 
     @Nonnull
-    default List<CmsObject> listAllCmsObjects() {
+    default List<CmsObject> listAllCmsObjects() throws ThreescaleCmsException {
         return streamAllCmsObjects()
             .collect(Collectors.toList());
     }
@@ -34,7 +34,7 @@ public interface ThreescaleCmsClient {
     Stream<CmsSection> streamSections();
 
     @Nonnull
-    default List<CmsSection> listSections() {
+    default List<CmsSection> listSections() throws ThreescaleCmsException {
         return streamSections()
             .collect(Collectors.toList());
     }
@@ -43,86 +43,69 @@ public interface ThreescaleCmsClient {
     Stream<CmsFile> streamFiles();
 
     @Nonnull
-    default List<CmsFile> listFiles() {
+    default List<CmsFile> listFiles() throws ThreescaleCmsException {
         return streamFiles()
             .collect(Collectors.toList());
     }
 
     @Nonnull
-    Optional<InputStream> getFileContent(long fileId) throws ApiException;
+    Optional<InputStream> getFileContent(long fileId) throws ThreescaleCmsException;
 
     @Nonnull
-    default Optional<InputStream> getFileContent(@Nonnull CmsFile file) {
+    default Optional<InputStream> getFileContent(@Nonnull CmsFile file) throws ThreescaleCmsException {
         return Optional.of(file)
             .map(CmsFile::getId)
-            .flatMap(fileId -> {
-                try {
-                    return getFileContent(fileId);
-                } catch (ApiException e) {
-                    // TODO: Create ThreescaleCmsException and throw it instead of RuntimeException
-                    throw new RuntimeException(e);
-                }
-            });
+            .flatMap(this::getFileContent);
     }
 
     @Nonnull
     Stream<CmsTemplate> streamTemplates(boolean includeContent);
 
     @Nonnull
-    default List<CmsTemplate> listTemplates(boolean includeContent) {
+    default List<CmsTemplate> listTemplates(boolean includeContent) throws ThreescaleCmsException {
         return streamTemplates(includeContent)
             .collect(Collectors.toList());
     }
 
     @Nonnull
-    Optional<InputStream> getTemplateDraft(long templateId) throws ApiException;
+    Optional<InputStream> getTemplateDraft(long templateId) throws ThreescaleCmsException;
 
     @Nonnull
-    default Optional<InputStream> getTemplateDraft(@Nonnull CmsTemplate template) {
+    default Optional<InputStream> getTemplateDraft(@Nonnull CmsTemplate template) throws ThreescaleCmsException {
         return Optional.of(template)
             .map(CmsTemplate::getId)
-            .flatMap(templateId -> {
-                try {
-                    return getTemplateDraft(templateId);
-                } catch (ApiException e) {
-                    // TODO: Create ThreescaleCmsException and throw it instead of RuntimeException
-                    throw new RuntimeException(e);
-                }
-            });
+            .flatMap(this::getTemplateDraft);
     }
 
     @Nonnull
-    Optional<InputStream> getTemplatePublished(long templateId) throws ApiException;
+    Optional<InputStream> getTemplatePublished(long templateId) throws ThreescaleCmsException;
 
     @Nonnull
-    default Optional<InputStream> getTemplatePublished(@Nonnull CmsTemplate template) {
+    default Optional<InputStream> getTemplatePublished(@Nonnull CmsTemplate template) throws ThreescaleCmsException {
         return Optional.of(template)
             .map(CmsTemplate::getId)
-            .flatMap(templateId -> {
-                try {
-                    return getTemplatePublished(templateId);
-                } catch (ApiException e) {
-                    // TODO: Create ThreescaleCmsException and throw it instead of RuntimeException
-                    throw new RuntimeException(e);
-                }
-            });
+            .flatMap(this::getTemplatePublished);
     }
 
-    void save(@Nonnull CmsSection section) throws ApiException;
+    void save(@Nonnull CmsSection section) throws ThreescaleCmsException;
 
-    void save(@Nonnull CmsFile file, @Nonnull File fileContent) throws ApiException;
+    void save(@Nonnull CmsFile file, @Nonnull File fileContent) throws ThreescaleCmsException;
 
-    void save(@Nonnull CmsTemplate template, @Nonnull File draft) throws ApiException;
+    void save(@Nonnull CmsTemplate template, @Nonnull File draft) throws ThreescaleCmsException;
 
-    void publish(long templateId) throws ApiException;
+    void publish(long templateId) throws ThreescaleCmsException;
 
-    default void publish(@Nonnull CmsTemplate template) throws ApiException {
-        publish(template.getId());
+    default void publish(@Nonnull CmsTemplate template) throws ThreescaleCmsException {
+        publish(Objects.requireNonNull(template.getId()));
     }
 
-    void delete(@Nonnull ThreescaleObjectType type, long id) throws ApiException;
+    void delete(@Nonnull ThreescaleObjectType type, long id) throws ThreescaleCmsException;
 
-    default void delete(@Nonnull CmsObject object) throws ApiException {
+    default void delete(@Nonnull CmsObject object) throws ThreescaleCmsException {
+        if (object.isBuiltin()) {
+            throw new ThreescaleCmsCannotDeleteBuiltinException();
+        }
+
         if (object.getId() != null) {
             delete(object.getType(), object.getId());
         }

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/ThreescaleCmsClientFactory.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/ThreescaleCmsClientFactory.java
@@ -1,5 +1,6 @@
 package com.fwmotion.threescale.cms;
 
+import com.fwmotion.threescale.cms.exception.ThreescaleCmsNonApiException;
 import com.fwmotion.threescale.cms.support.ApiClientBuilder;
 import com.redhat.threescale.rest.cms.ApiClient;
 import com.redhat.threescale.rest.cms.auth.ApiKeyAuth;
@@ -34,8 +35,7 @@ public class ThreescaleCmsClientFactory implements AutoCloseable {
             try {
                 httpClient.close();
             } catch (IOException e) {
-                // TODO: Create ThreescaleCmsException and throw it instead of IllegalStateException
-                throw new IllegalStateException("Couldn't close old HTTP client", e);
+                throw new ThreescaleCmsNonApiException("Couldn't close old HTTP client", e);
             }
         }
         httpClient = null;
@@ -58,8 +58,7 @@ public class ThreescaleCmsClientFactory implements AutoCloseable {
                         .build();
                 } catch (NoSuchAlgorithmException | KeyManagementException |
                          KeyStoreException e) {
-                    // TODO: Create ThreescaleCmsException and throw it instead of IllegalStateException
-                    throw new IllegalStateException("Unable to create insecure HttpClient", e);
+                    throw new ThreescaleCmsNonApiException("Unable to create insecure HttpClient", e);
                 }
             } else {
                 httpClient = HttpClients.createDefault();
@@ -81,8 +80,7 @@ public class ThreescaleCmsClientFactory implements AutoCloseable {
             Authentication accessTokenAuth = apiClient.getAuthentication("access_token");
             ((ApiKeyAuth) accessTokenAuth).setApiKey(apiClient.escapeString(accessToken));
         } else {
-            // TODO: Create ThreescaleCmsException and throw it instead of IllegalStateException
-            throw new IllegalStateException("Authentication not set for 3scale CMS client; must provide one of: providerKey, accessToken");
+            throw new ThreescaleCmsNonApiException("Authentication not set for 3scale CMS client; must provide one of: providerKey, accessToken");
         }
 
         return apiClient;

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/exception/ThreescaleCmsApiException.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/exception/ThreescaleCmsApiException.java
@@ -1,0 +1,85 @@
+package com.fwmotion.threescale.cms.exception;
+
+import com.redhat.threescale.rest.cms.model.Error;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+
+import java.util.Optional;
+
+/**
+ * Common base exception type for all 3scale CMS-related API exceptions
+ */
+public class ThreescaleCmsApiException extends ThreescaleCmsException {
+
+    private final int httpStatus;
+    private final Error apiError;
+
+    public ThreescaleCmsApiException(
+        int httpStatus,
+        @Nullable Error apiError,
+        @Nullable String message
+    ) {
+        super(message);
+        this.httpStatus = httpStatus;
+        this.apiError = apiError;
+    }
+
+    public ThreescaleCmsApiException(
+        int httpStatus,
+        @Nullable String message
+    ) {
+        this(httpStatus, null, message);
+    }
+
+    public ThreescaleCmsApiException(
+        int httpStatus,
+        @Nullable Error apiError
+    ) {
+        this(httpStatus,
+            apiError,
+            Optional.ofNullable(apiError)
+                .map(Error::getError)
+                .orElse(null));
+    }
+
+    public ThreescaleCmsApiException(
+        int httpStatus,
+        @Nullable Error apiError,
+        @Nullable String message,
+        @Nonnull Throwable cause
+    ) {
+        super(message, cause);
+        this.httpStatus = httpStatus;
+        this.apiError = apiError;
+    }
+
+    public ThreescaleCmsApiException(
+        int httpStatus,
+        @Nullable String message,
+        @Nonnull Throwable cause
+    ) {
+        this(httpStatus, null, message, cause);
+    }
+
+    public ThreescaleCmsApiException(
+        int httpStatus,
+        @Nullable Error apiError,
+        @Nonnull Throwable cause
+    ) {
+        this(httpStatus,
+            apiError,
+            Optional.ofNullable(apiError)
+                .map(Error::getError)
+                .orElse(null),
+            cause);
+    }
+
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Nonnull
+    public Optional<Error> getApiError() {
+        return Optional.ofNullable(apiError);
+    }
+}

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/exception/ThreescaleCmsCannotCreateBuiltinException.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/exception/ThreescaleCmsCannotCreateBuiltinException.java
@@ -1,0 +1,14 @@
+package com.fwmotion.threescale.cms.exception;
+
+import jakarta.annotation.Nonnull;
+import org.apache.hc.core5.http.HttpStatus;
+
+public class ThreescaleCmsCannotCreateBuiltinException extends ThreescaleCmsApiException {
+
+    public static final int ERROR_HTTP_STATUS = HttpStatus.SC_BAD_REQUEST;
+
+    public ThreescaleCmsCannotCreateBuiltinException(@Nonnull String message) {
+        super(ERROR_HTTP_STATUS, message);
+    }
+
+}

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/exception/ThreescaleCmsCannotDeleteBuiltinException.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/exception/ThreescaleCmsCannotDeleteBuiltinException.java
@@ -1,0 +1,28 @@
+package com.fwmotion.threescale.cms.exception;
+
+import com.redhat.threescale.rest.cms.model.Error;
+import jakarta.annotation.Nonnull;
+import org.apache.hc.core5.http.HttpStatus;
+
+public class ThreescaleCmsCannotDeleteBuiltinException extends ThreescaleCmsApiException {
+
+    /**
+     * The HTTP status code sent by 3scale when this error occurs
+     */
+    public static final int ERROR_HTTP_CODE = HttpStatus.SC_UNPROCESSABLE_ENTITY;
+
+    /**
+     * The error message sent by 3scale to indicate this type of error
+     */
+    public static final String ERROR_MESSAGE = "Built-in resources can't be deleted";
+
+    public ThreescaleCmsCannotDeleteBuiltinException() {
+        super(ERROR_HTTP_CODE,
+            new Error()
+                .error(ERROR_MESSAGE));
+    }
+    public ThreescaleCmsCannotDeleteBuiltinException(@Nonnull Error apiError) {
+        super(HttpStatus.SC_UNPROCESSABLE_ENTITY,
+            apiError);
+    }
+}

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/exception/ThreescaleCmsException.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/exception/ThreescaleCmsException.java
@@ -1,0 +1,16 @@
+package com.fwmotion.threescale.cms.exception;
+
+/**
+ * Common base exception type for all 3scale CMS-related exceptions
+ */
+public class ThreescaleCmsException extends RuntimeException {
+
+    protected ThreescaleCmsException(String message) {
+        super(message);
+    }
+
+    protected ThreescaleCmsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/exception/ThreescaleCmsNonApiException.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/exception/ThreescaleCmsNonApiException.java
@@ -1,0 +1,15 @@
+package com.fwmotion.threescale.cms.exception;
+
+/**
+ * Base class for exceptions not directly related to the CMS API, such as
+ * IO Exceptions
+ */
+public class ThreescaleCmsNonApiException extends ThreescaleCmsException {
+    public ThreescaleCmsNonApiException(String message) {
+        super(message);
+    }
+
+    public ThreescaleCmsNonApiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/exception/ThreescaleCmsUnexpectedPaginationException.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/exception/ThreescaleCmsUnexpectedPaginationException.java
@@ -1,0 +1,23 @@
+package com.fwmotion.threescale.cms.exception;
+
+import jakarta.annotation.Nonnull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import org.apache.hc.core5.http.HttpStatus;
+
+public class ThreescaleCmsUnexpectedPaginationException extends ThreescaleCmsApiException {
+
+    public ThreescaleCmsUnexpectedPaginationException(
+        @Nonnull String type,
+        @PositiveOrZero int pageNumber,
+        @Positive int requestedPageSize,
+        @Positive int expectedPageSize,
+        @Positive int actualPageSize
+    ) {
+        super(HttpStatus.SC_OK,
+            "Unexpected page size for " + type + " list page " + pageNumber
+                + " (with page size of " + requestedPageSize
+                + "); parsed page size is " + actualPageSize
+                + " but expected size of " + expectedPageSize);
+    }
+}

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/mappers/CmsFileMapper.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/mappers/CmsFileMapper.java
@@ -15,10 +15,8 @@ import java.util.stream.Collectors;
 @Mapper
 public interface CmsFileMapper {
 
-    @Mapping(target = "tags", source = "tagList")
     CmsFile fromRest(ModelFile file);
 
-    @Mapping(target = "tagList", source = "tags")
     // title is only the filename without path... not useful
     @Mapping(target = "title", ignore = true)
     // url is the S3 or local filesystem location for 3scale... not useful

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsBuiltinPage.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsBuiltinPage.java
@@ -1,12 +1,13 @@
 package com.fwmotion.threescale.cms.model;
 
+import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.time.OffsetDateTime;
 
-public class CmsBuiltinPage implements CmsTemplate {
+public class CmsBuiltinPage implements CmsBuiltinTemplate {
 
     private OffsetDateTime createdAt;
     private OffsetDateTime updatedAt;
@@ -38,6 +39,7 @@ public class CmsBuiltinPage implements CmsTemplate {
         this.updatedAt = updatedAt;
     }
 
+    @Nullable
     @Override
     public Long getId() {
         return id;
@@ -115,9 +117,7 @@ public class CmsBuiltinPage implements CmsTemplate {
     public boolean equals(Object o) {
         if (this == o) return true;
 
-        if (!(o instanceof CmsBuiltinPage)) return false;
-
-        CmsBuiltinPage that = (CmsBuiltinPage) o;
+        if (!(o instanceof CmsBuiltinPage that)) return false;
 
         return new EqualsBuilder().append(getId(), that.getId()).isEquals();
     }

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsBuiltinPartial.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsBuiltinPartial.java
@@ -1,12 +1,13 @@
 package com.fwmotion.threescale.cms.model;
 
+import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.time.OffsetDateTime;
 
-public class CmsBuiltinPartial implements CmsTemplate {
+public class CmsBuiltinPartial implements CmsBuiltinTemplate {
 
     private OffsetDateTime createdAt;
     private OffsetDateTime updatedAt;
@@ -34,6 +35,7 @@ public class CmsBuiltinPartial implements CmsTemplate {
         this.updatedAt = updatedAt;
     }
 
+    @Nullable
     @Override
     public Long getId() {
         return id;
@@ -79,9 +81,7 @@ public class CmsBuiltinPartial implements CmsTemplate {
     public boolean equals(Object o) {
         if (this == o) return true;
 
-        if (!(o instanceof CmsBuiltinPartial)) return false;
-
-        CmsBuiltinPartial that = (CmsBuiltinPartial) o;
+        if (!(o instanceof CmsBuiltinPartial that)) return false;
 
         return new EqualsBuilder().append(getId(), that.getId()).isEquals();
     }

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsBuiltinTemplate.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsBuiltinTemplate.java
@@ -1,0 +1,10 @@
+package com.fwmotion.threescale.cms.model;
+
+public interface CmsBuiltinTemplate extends CmsTemplate {
+
+    @Override
+    default boolean isBuiltin() {
+        return true;
+    }
+
+}

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsFile.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsFile.java
@@ -1,11 +1,12 @@
 package com.fwmotion.threescale.cms.model;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.time.OffsetDateTime;
-import java.util.Set;
 
 public class CmsFile implements CmsObject {
 
@@ -14,10 +15,10 @@ public class CmsFile implements CmsObject {
     private Long id;
     private Long sectionId;
     private String path;
-    private Set<String> tags;
     private Boolean downloadable;
     private String contentType;
 
+    @Nonnull
     @Override
     public ThreescaleObjectType getType() {
         return ThreescaleObjectType.FILE;
@@ -41,6 +42,7 @@ public class CmsFile implements CmsObject {
         this.updatedAt = updatedAt;
     }
 
+    @Nullable
     @Override
     public Long getId() {
         return id;
@@ -64,14 +66,6 @@ public class CmsFile implements CmsObject {
 
     public void setPath(String path) {
         this.path = path;
-    }
-
-    public Set<String> getTags() {
-        return tags;
-    }
-
-    public void setTags(Set<String> tags) {
-        this.tags = tags;
     }
 
     public Boolean getDownloadable() {
@@ -112,7 +106,6 @@ public class CmsFile implements CmsObject {
             .append("id", id)
             .append("sectionId", sectionId)
             .append("path", path)
-            .append("tags", tags)
             .append("downloadable", downloadable)
             .toString();
     }

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsLayout.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsLayout.java
@@ -1,5 +1,6 @@
 package com.fwmotion.threescale.cms.model;
 
+import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -37,6 +38,7 @@ public class CmsLayout implements CmsTemplate {
         this.updatedAt = updatedAt;
     }
 
+    @Nullable
     @Override
     public Long getId() {
         return id;

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsObject.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsObject.java
@@ -1,11 +1,20 @@
 package com.fwmotion.threescale.cms.model;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+
 import java.time.OffsetDateTime;
 
 public interface CmsObject {
 
+    default boolean isBuiltin() {
+        return false;
+    }
+
+    @Nonnull
     ThreescaleObjectType getType();
 
+    @Nullable
     Long getId();
 
     OffsetDateTime getCreatedAt();

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsPage.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsPage.java
@@ -1,5 +1,6 @@
 package com.fwmotion.threescale.cms.model;
 
+import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -38,6 +39,7 @@ public class CmsPage implements CmsTemplate {
         this.updatedAt = updatedAt;
     }
 
+    @Nullable
     @Override
     public Long getId() {
         return id;
@@ -115,9 +117,7 @@ public class CmsPage implements CmsTemplate {
     public boolean equals(Object o) {
         if (this == o) return true;
 
-        if (!(o instanceof CmsPage)) return false;
-
-        CmsPage cmsPage = (CmsPage) o;
+        if (!(o instanceof CmsPage cmsPage)) return false;
 
         return new EqualsBuilder().append(getId(), cmsPage.getId()).isEquals();
     }

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsPartial.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsPartial.java
@@ -1,5 +1,6 @@
 package com.fwmotion.threescale.cms.model;
 
+import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -34,6 +35,7 @@ public class CmsPartial implements CmsTemplate {
         this.updatedAt = updatedAt;
     }
 
+    @Nullable
     @Override
     public Long getId() {
         return id;
@@ -79,9 +81,7 @@ public class CmsPartial implements CmsTemplate {
     public boolean equals(Object o) {
         if (this == o) return true;
 
-        if (!(o instanceof CmsPartial)) return false;
-
-        CmsPartial that = (CmsPartial) o;
+        if (!(o instanceof CmsPartial that)) return false;
 
         return new EqualsBuilder().append(getId(), that.getId()).isEquals();
     }

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsSection.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsSection.java
@@ -1,5 +1,7 @@
 package com.fwmotion.threescale.cms.model;
 
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -17,6 +19,7 @@ public class CmsSection implements CmsObject {
     private Boolean _public;
     private String path;
 
+    @Nonnull
     @Override
     public ThreescaleObjectType getType() {
         return ThreescaleObjectType.SECTION;
@@ -40,6 +43,7 @@ public class CmsSection implements CmsObject {
         this.updatedAt = updatedAt;
     }
 
+    @Nullable
     @Override
     public Long getId() {
         return id;

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsTemplate.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/model/CmsTemplate.java
@@ -1,7 +1,10 @@
 package com.fwmotion.threescale.cms.model;
 
+import jakarta.annotation.Nonnull;
+
 public interface CmsTemplate extends CmsObject {
 
+    @Nonnull
     @Override
     default ThreescaleObjectType getType() {
         return ThreescaleObjectType.TEMPLATE;

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/support/ApiClientBuilder.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/support/ApiClientBuilder.java
@@ -12,11 +12,11 @@ public final class ApiClientBuilder {
     }
 
     public static ApiClient buildApiClient(CloseableHttpClient httpClient) {
-        ApiClient xmlApiClient = new ApiClient(httpClient);
+        ApiClient apiClient = new ApiClient(httpClient);
 
-        applyMixIns(xmlApiClient.getObjectMapper());
+        applyMixIns(apiClient.getObjectMapper());
 
-        return xmlApiClient;
+        return apiClient;
     }
 
     /**

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/support/PagedFilesSpliterator.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/support/PagedFilesSpliterator.java
@@ -1,5 +1,6 @@
 package com.fwmotion.threescale.cms.support;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fwmotion.threescale.cms.mappers.CmsFileMapper;
 import com.fwmotion.threescale.cms.model.CmsFile;
 import com.redhat.threescale.rest.cms.ApiException;
@@ -21,22 +22,25 @@ public class PagedFilesSpliterator extends AbstractPagedRestApiSpliterator<CmsFi
 
     private final FilesApi filesApi;
 
-    public PagedFilesSpliterator(@Nonnull FilesApi filesApi) {
-        super(Collections.emptySet(), 0);
+    public PagedFilesSpliterator(@Nonnull FilesApi filesApi,
+                                 @Nonnull ObjectMapper objectMapper) {
+        super(Collections.emptySet(), objectMapper, 0);
         this.filesApi = filesApi;
     }
 
     public PagedFilesSpliterator(@Nonnull FilesApi filesApi,
+                                 @Nonnull ObjectMapper objectMapper,
                                  @Positive int requestedPageSize) {
-        super(requestedPageSize, Collections.emptySet(), 0);
+        super(requestedPageSize, objectMapper, Collections.emptySet(), 0);
         this.filesApi = filesApi;
     }
 
     private PagedFilesSpliterator(@Nonnull FilesApi filesApi,
+                                  @Nonnull ObjectMapper objectMapper,
                                   @Positive int requestedPageSize,
                                   @Nonnull Collection<CmsFile> currentPage,
                                   @PositiveOrZero int currentPageNumber) {
-        super(requestedPageSize, currentPage, currentPageNumber);
+        super(requestedPageSize, objectMapper, currentPage, currentPageNumber);
         this.filesApi = filesApi;
     }
 
@@ -62,9 +66,7 @@ public class PagedFilesSpliterator extends AbstractPagedRestApiSpliterator<CmsFi
 
             return resultPage;
         } catch (ApiException e) {
-            // TODO: Create ThreescaleCmsException and throw it instead of IllegalStateException
-            throw new IllegalStateException("Unexpected exception while iterating CMS file page " + pageNumber
-                + " (with page size of " + pageSize + ")", e);
+            throw handleApiException(e, "file", pageNumber, pageSize);
         }
     }
 
@@ -74,7 +76,7 @@ public class PagedFilesSpliterator extends AbstractPagedRestApiSpliterator<CmsFi
         @Positive int requestedPageSize,
         @Nonnull Collection<CmsFile> currentPage,
         @PositiveOrZero int currentPageNumber) {
-        return new PagedFilesSpliterator(filesApi, requestedPageSize, currentPage, currentPageNumber);
+        return new PagedFilesSpliterator(filesApi, getObjectMapper(), requestedPageSize, currentPage, currentPageNumber);
     }
 
     @Override

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/support/PagedSectionsSpliterator.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/support/PagedSectionsSpliterator.java
@@ -1,5 +1,6 @@
 package com.fwmotion.threescale.cms.support;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fwmotion.threescale.cms.mappers.CmsSectionMapper;
 import com.fwmotion.threescale.cms.model.CmsSection;
 import com.redhat.threescale.rest.cms.ApiException;
@@ -21,22 +22,24 @@ public class PagedSectionsSpliterator extends AbstractPagedRestApiSpliterator<Cm
 
     private final SectionsApi sectionsApi;
 
-    public PagedSectionsSpliterator(@Nonnull SectionsApi sectionsApi) {
-        super(Collections.emptySet(), 0);
+    public PagedSectionsSpliterator(@Nonnull SectionsApi sectionsApi, @Nonnull ObjectMapper objectMapper) {
+        super(Collections.emptySet(), objectMapper, 0);
         this.sectionsApi = sectionsApi;
     }
 
     public PagedSectionsSpliterator(@Nonnull SectionsApi sectionsApi,
+                                    @Nonnull ObjectMapper objectMapper,
                                     @Positive int requestedPageSize) {
-        super(requestedPageSize, Collections.emptySet(), 0);
+        super(requestedPageSize, objectMapper, Collections.emptySet(), 0);
         this.sectionsApi = sectionsApi;
     }
 
     private PagedSectionsSpliterator(@Nonnull SectionsApi sectionsApi,
+                                     @Nonnull ObjectMapper objectMapper,
                                      @Positive int requestedPageSize,
                                      @Nonnull Collection<CmsSection> currentPage,
                                      @PositiveOrZero int currentPageNumber) {
-        super(requestedPageSize, currentPage, currentPageNumber);
+        super(requestedPageSize, objectMapper, currentPage, currentPageNumber);
         this.sectionsApi = sectionsApi;
     }
 
@@ -62,9 +65,7 @@ public class PagedSectionsSpliterator extends AbstractPagedRestApiSpliterator<Cm
 
             return resultPage;
         } catch (ApiException e) {
-            // TODO: Create ThreescaleCmsException and throw it instead of IllegalStateException
-            throw new IllegalStateException("Unexpected exception while iterating CMS section list page " + pageNumber
-                + " (with page size of " + pageSize + ")", e);
+            throw handleApiException(e, "section", pageNumber, pageSize);
         }
     }
 
@@ -74,7 +75,7 @@ public class PagedSectionsSpliterator extends AbstractPagedRestApiSpliterator<Cm
         @Positive int requestedPageSize,
         @Nonnull Collection<CmsSection> currentPage,
         @PositiveOrZero int currentPageNumber) {
-        return new PagedSectionsSpliterator(sectionsApi, requestedPageSize, currentPage, currentPageNumber);
+        return new PagedSectionsSpliterator(sectionsApi, getObjectMapper(), requestedPageSize, currentPage, currentPageNumber);
     }
 
     @Override

--- a/rest-client/src/main/java/com/fwmotion/threescale/cms/support/PagedTemplatesSpliterator.java
+++ b/rest-client/src/main/java/com/fwmotion/threescale/cms/support/PagedTemplatesSpliterator.java
@@ -1,5 +1,6 @@
 package com.fwmotion.threescale.cms.support;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fwmotion.threescale.cms.mappers.CmsTemplateMapper;
 import com.fwmotion.threescale.cms.model.CmsTemplate;
 import com.redhat.threescale.rest.cms.ApiException;
@@ -23,26 +24,29 @@ public class PagedTemplatesSpliterator extends AbstractPagedRestApiSpliterator<C
     private final boolean includeContent;
 
     public PagedTemplatesSpliterator(@Nonnull TemplatesApi templatesApi,
+                                     @Nonnull ObjectMapper objectMapper,
                                      boolean includeContent) {
-        super(Collections.emptySet(), 0);
+        super(Collections.emptySet(), objectMapper, 0);
         this.templatesApi = templatesApi;
         this.includeContent = includeContent;
     }
 
     public PagedTemplatesSpliterator(@Nonnull TemplatesApi templatesApi,
+                                     @Nonnull ObjectMapper objectMapper,
                                      boolean includeContent,
                                      @Positive int requestedPageSize) {
-        super(requestedPageSize, Collections.emptySet(), 0);
+        super(requestedPageSize, objectMapper, Collections.emptySet(), 0);
         this.templatesApi = templatesApi;
         this.includeContent = includeContent;
     }
 
     private PagedTemplatesSpliterator(@Nonnull TemplatesApi templatesApi,
+                                      @Nonnull ObjectMapper objectMapper,
                                       boolean includeContent,
                                       @Positive int requestedPageSize,
                                       @Nonnull Collection<CmsTemplate> currentPage,
                                       @PositiveOrZero int currentPageNumber) {
-        super(requestedPageSize, currentPage, currentPageNumber);
+        super(requestedPageSize, objectMapper, currentPage, currentPageNumber);
         this.templatesApi = templatesApi;
         this.includeContent = includeContent;
     }
@@ -74,9 +78,7 @@ public class PagedTemplatesSpliterator extends AbstractPagedRestApiSpliterator<C
 
             return resultPage;
         } catch (ApiException e) {
-            // TODO: Create ThreescaleCmsException and throw it instead of IllegalStateException
-            throw new IllegalStateException("Unexpected exception while iterating CMS template list page " + pageNumber
-                + " (with page size of " + pageSize + ")", e);
+            throw handleApiException(e, "template", pageNumber, pageSize);
         }
     }
 
@@ -85,10 +87,13 @@ public class PagedTemplatesSpliterator extends AbstractPagedRestApiSpliterator<C
     protected AbstractPagedRestApiSpliterator<CmsTemplate> doSplit(
         @Positive int requestedPageSize,
         @Nonnull Collection<CmsTemplate> currentPage,
-        @PositiveOrZero int currentPageNumber) {
+        @PositiveOrZero int currentPageNumber
+    ) {
         return new PagedTemplatesSpliterator(
             templatesApi,
-            includeContent, requestedPageSize,
+            getObjectMapper(),
+            includeContent,
+            requestedPageSize,
             currentPage,
             currentPageNumber
         );

--- a/rest-client/src/main/resources/api-spec/3scale-cms.yaml
+++ b/rest-client/src/main/resources/api-spec/3scale-cms.yaml
@@ -16,6 +16,9 @@ servers:
 paths:
   /admin/api/cms/files.json:
     get:
+      operationId: list-files
+      summary: List Files
+      description: List files held within the 3scale CMS
       tags:
         - Files
       parameters:
@@ -23,99 +26,99 @@ paths:
           description: |
             The number for the page of results to retrieve, starting from page 1;
             defaults to 1
+          in: query
+          required: false
           schema:
             type: integer
             minimum: 1
             default: 1
-          in: query
-          required: false
         - name: per_page
           description: |
             The number of items to retrieve per page of results; defaults to 20
+          in: query
+          required: false
           schema:
             type: integer
             minimum: 1
             maximum: 100
             default: 20
-          required: false
-          in: query
         - name: section_id
           description: The section to query for files (hidden option in CMS API)
+          in: query
+          required: false
           schema:
             $ref: '#/components/schemas/SectionId'
-          required: false
-          in: query
       responses:
         '200':
           $ref: '#/components/responses/FileListResponse'
-      operationId: list-files
-      summary: List Files
-      description: List files held within the 3scale CMS
     post:
+      operationId: create-file
+      summary: Create File
+      description: Create file within the 3scale CMS
+      tags:
+        - Files
       requestBody:
+        required: true
         content:
           multipart/form-data:
             schema:
               $ref: '#/components/schemas/FileCreationRequest'
-        required: true
-      tags:
-        - Files
       responses:
         '201':
           $ref: '#/components/responses/FileResponse'
         '422':
-          $ref: '#/components/responses/ErrorListResponse'
+          $ref: '#/components/responses/ErrorResponse'
         '500':
-          $ref: '#/components/responses/ErrorHashResponse'
-      operationId: create-file
-      summary: Create File
-      description: Create file within the 3scale CMS
+          $ref: '#/components/responses/ErrorResponse'
   '/admin/api/cms/files/{file_id}.json':
+    parameters:
+      - name: file_id
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/FileId'
     get:
+      operationId: get-file
+      summary: Get File
+      description: Get a file descriptor
       tags:
         - Files
       responses:
         '200':
           $ref: '#/components/responses/FileResponse'
-      operationId: get-file
-      summary: Get File
-      description: Get a file descriptor
     put:
+      operationId: update-file
+      summary: Update File
+      description: Update an existing file
+      tags:
+        - Files
       requestBody:
+        required: true
         content:
           multipart/form-data:
             schema:
               $ref: '#/components/schemas/FileUpdatableFields'
-        required: true
-      tags:
-        - Files
       responses:
         '200':
           $ref: '#/components/responses/FileResponse'
         '422':
-          $ref: '#/components/responses/ErrorListResponse'
+          $ref: '#/components/responses/ErrorResponse'
         '500':
-          $ref: '#/components/responses/ErrorHashResponse'
-      operationId: update-file
-      summary: Update File
-      description: Update an existing file
+          $ref: '#/components/responses/ErrorResponse'
     delete:
+      operationId: delete-file
+      summary: Delete File
+      description: Delete a file from 3scale CMS
       tags:
         - Files
       responses:
         '200':
           $ref: '#/components/responses/EmptyResponse'
-      operationId: delete-file
-      summary: Delete File
-      description: Delete a file from 3scale CMS
-    parameters:
-      - name: file_id
-        schema:
-          $ref: '#/components/schemas/FileId'
-        in: path
-        required: true
   /admin/api/cms/sections.json:
     get:
+      operationId: list-sections
+      summary: List Sections
+      description: List sections held within the 3scale CMS
       tags:
         - Sections
       parameters:
@@ -123,28 +126,25 @@ paths:
           description: |
             The number for the page of results to retrieve, starting from page 1;
             defaults to 1
+          in: query
+          required: false
           schema:
             type: integer
             minimum: 1
             default: 1
-          in: query
-          required: false
         - name: per_page
           description: |
             The number of items to retrieve per page of results; defaults to 20
+          in: query
+          required: false
           schema:
             type: integer
             minimum: 1
             maximum: 100
             default: 20
-          required: false
-          in: query
       responses:
         '200':
           $ref: '#/components/responses/SectionListResponse'
-      operationId: list-sections
-      summary: List Sections
-      description: List sections held within the 3scale CMS
     post:
       requestBody:
         content:
@@ -158,42 +158,51 @@ paths:
         '201':
           $ref: '#/components/responses/SectionResponse'
         '422':
-          $ref: '#/components/responses/ErrorListResponse'
+          $ref: '#/components/responses/ErrorResponse'
         '500':
-          $ref: '#/components/responses/ErrorHashResponse'
+          $ref: '#/components/responses/ErrorResponse'
       operationId: create-section
       summary: Create Section
       description: Create section within the 3scale CMS
   '/admin/api/cms/sections/{section_id}.json':
+    parameters:
+      - name: section_id
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/SectionId'
     get:
+      operationId: get-section
+      summary: Get Section
+      description: Get section descriptor
       tags:
         - Sections
       responses:
         '200':
           $ref: '#/components/responses/SectionResponse'
-      operationId: get-section
-      summary: Get Section
-      description: Get section descriptor
     put:
+      operationId: update-section
+      summary: Update Section
+      description: Update section descriptor
+      tags:
+        - Sections
       requestBody:
+        required: true
         content:
           multipart/form-data:
             schema:
               $ref: '#/components/schemas/SectionUpdatableFields'
-        required: true
-      tags:
-        - Sections
       responses:
         '200':
           $ref: '#/components/responses/SectionResponse'
         '422':
-          $ref: '#/components/responses/ErrorListResponse'
+          $ref: '#/components/responses/ErrorResponse'
         '500':
-          $ref: '#/components/responses/ErrorHashResponse'
-      operationId: update-section
-      summary: Update Section
-      description: Update section descriptor
+          $ref: '#/components/responses/ErrorResponse'
     delete:
+      operationId: delete-section
+      summary: Delete Section
+      description: Delete a section from 3scale CMS
       tags:
         - Sections
       responses:
@@ -201,61 +210,55 @@ paths:
           $ref: '#/components/responses/EmptyResponse'
         '423':
           $ref: '#/components/responses/EmptyResponse'
-      operationId: delete-section
-      summary: Delete Section
-      description: Delete a section from 3scale CMS
+  '/admin/api/cms/sections/{system_name}.json':
     parameters:
-      - name: section_id
-        schema:
-          $ref: '#/components/schemas/SectionId'
+      - name: system_name
         in: path
         required: true
-  '/admin/api/cms/sections/{system_name}.json':
+        schema:
+          $ref: '#/components/schemas/SystemName'
     get:
+      operationId: get-section-by-system-name
+      summary: Get Section by System Name
+      description: Get section descriptor
       tags:
         - Sections
       responses:
         '200':
           $ref: '#/components/responses/SectionResponse'
-      operationId: get-section-by-system-name
-      summary: Get Section by System Name
-      description: Get section descriptor
     put:
+      operationId: update-section-by-system-name
+      summary: Update Section by System Name
+      description: Update section descriptor
+      tags:
+        - Sections
       requestBody:
         content:
           multipart/form-data:
             schema:
               $ref: '#/components/schemas/SectionUpdatableFields'
         required: true
-      tags:
-        - Sections
       responses:
         '200':
           $ref: '#/components/responses/SectionResponse'
         '422':
-          $ref: '#/components/responses/ErrorListResponse'
+          $ref: '#/components/responses/ErrorResponse'
         '500':
-          $ref: '#/components/responses/ErrorHashResponse'
-      operationId: update-section-by-system-name
-      summary: Update Section by System Name
-      description: Update section descriptor
+          $ref: '#/components/responses/ErrorResponse'
     delete:
+      operationId: delete-section-by-system-name
+      summary: Delete Section by System Name
+      description: Delete a section from 3scale CMS
       tags:
         - Sections
       responses:
         '200':
           $ref: '#/components/responses/EmptyResponse'
-      operationId: delete-section-by-system-name
-      summary: Delete Section by System Name
-      description: Delete a section from 3scale CMS
-    parameters:
-      - name: system_name
-        schema:
-          $ref: '#/components/schemas/SystemName'
-        in: path
-        required: true
   /admin/api/cms/templates.json:
     get:
+      operationId: list-templates
+      summary: List Templates
+      description: List all templates contained in the 3scale CMS
       tags:
         - Templates
       parameters:
@@ -263,116 +266,117 @@ paths:
           description: |
             The number for the page of results to retrieve, starting from page 1;
             defaults to 1
+          in: query
+          required: false
           schema:
             type: integer
             minimum: 1
             default: 1
-          in: query
-          required: false
         - name: per_page
           description: |
             The number of items to retrieve per page of results; defaults to 20
+          in: query
+          required: false
           schema:
             type: integer
             minimum: 1
             maximum: 100
             default: 20
-          required: false
-          in: query
         - name: content
           description: |
             Whether to include the draft and published content in listed
             templates
+          in: query
+          required: false
           schema:
             type: boolean
-          required: false
-          in: query
       responses:
         '200':
           $ref: '#/components/responses/TemplateListResponse'
-      operationId: list-templates
-      summary: List Templates
-      description: List all templates contained in the 3scale CMS
     post:
-      requestBody:
-        content:
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/TemplateCreationRequest'
-        required: true
+      operationId: create-template
+      summary: Create Template
+      description: Create template with the 3scale CMS
       tags:
         - Templates
+      requestBody:
+        required: true
+        content:
+          # 3scale gives an Internal Server Error when
+          # multipart/form-data is used for this
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TemplateCreationRequest'
       responses:
         '201':
           $ref: '#/components/responses/TemplateResponse'
         '422':
-          $ref: '#/components/responses/ErrorListResponse'
+          $ref: '#/components/responses/ErrorResponse'
         '500':
-          $ref: '#/components/responses/ErrorHashResponse'
-      operationId: create-template
-      summary: Create Template
-      description: Create template with the 3scale CMS
+          $ref: '#/components/responses/ErrorResponse'
   '/admin/api/cms/templates/{template_id}.json':
+    parameters:
+      - name: template_id
+        in: path
+        required: true
+        schema:
+          $ref: '#/components/schemas/TemplateId'
     get:
-      tags:
-        - Templates
-      responses:
-        '200':
-          $ref: '#/components/responses/TemplateResponse'
       operationId: get-template
       summary: Get Template
       description: |-
         Retrieve a template of any kind from 3scale (TODO: double-check response)
-    put:
-      requestBody:
-        content:
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/TemplateUpdatableFields'
-        required: true
       tags:
         - Templates
       responses:
         '200':
           $ref: '#/components/responses/TemplateResponse'
-        '422':
-          $ref: '#/components/responses/ErrorListResponse'
-        '500':
-          $ref: '#/components/responses/ErrorHashResponse'
+    put:
       operationId: update-template
       summary: Update Template
       description: 'Update a template draft (TODO: double-check response)'
+      tags:
+        - Templates
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TemplateUpdatableFields'
+      responses:
+        '200':
+          $ref: '#/components/responses/TemplateResponse'
+        '422':
+          $ref: '#/components/responses/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/ErrorResponse'
     delete:
+      operationId: delete-template
+      summary: Delete Template
+      description: Delete a template from 3scale CMS
       tags:
         - Templates
       responses:
         '200':
           $ref: '#/components/responses/EmptyResponse'
-      operationId: delete-template
-      summary: Delete Template
-      description: Delete a template from 3scale CMS
-    parameters:
-      - name: template_id
-        schema:
-          $ref: '#/components/schemas/TemplateId'
-        in: path
-        required: true
+        '422':
+          $ref: '#/components/responses/ErrorResponse'
   '/admin/api/cms/templates/{template_id}/publish':
     put:
+      operationId: publish-template
+      summary: Publish Template
+      description: Move a template draft to be "published"
       tags:
         - Templates
       responses:
         '200':
           $ref: '#/components/responses/TemplateResponse'
-      operationId: publish-template
-      summary: Publish Template
-      description: Move a template draft to be "published"
     parameters:
       - name: template_id
-        schema:
-          $ref: '#/components/schemas/TemplateId'
         in: path
         required: true
+        schema:
+          $ref: '#/components/schemas/TemplateId'
   /admin/api/provider.json:
     get:
       operationId: read-provider-settings
@@ -381,8 +385,8 @@ paths:
         Read 3scale Provider (Tenant) settings; particularly related to
         the developer portal.
 
-        *Note:* This is technically part of the Account Management API, but is
-        used to determine the location and access-token for retrieving file
+        *Note:* This is technically part of 3scale's Account Management API, but
+        is used to determine the location and access-token for retrieving file
         content, so it is tagged with `Files`.
       tags:
         - Files
@@ -394,7 +398,8 @@ components:
     BuiltinPage:
       allOf:
         - $ref: '#/components/schemas/Template'
-        - properties:
+        - type: object
+          properties:
             path:
               type: string
               maxLength: 255
@@ -411,7 +416,8 @@ components:
     BuiltinPartial:
       allOf:
         - $ref: '#/components/schemas/Template'
-        - properties:
+        - type: object
+          properties:
             system_name:
               $ref: '#/components/schemas/SystemName'
       example:
@@ -437,38 +443,36 @@ components:
         - page
         - layout
         - partial
-    ErrorHash:
-      description: Unhandled server error on 3scale
+    Error:
+      description: Error message from the server
+      type: object
+      required:
+        - error
       properties:
         status:
+          description: Error code
           type: integer
-        toXml:
-          type: string
         error:
+          description: Error message
           type: string
-    ErrorList:
-      description: List of errors that occurred in processing a request
-      type: array
-      items:
-        description: |
-          Description of an individual error that occurred while processing
-          an event.
-        type: string
+      example:
+        error: Built-in resources can't be deleted
     File:
       description: File as held in the 3scale CMS
       allOf:
         - $ref: '#/components/schemas/FileUpdatableFields'
-        - properties:
+        - type: object
+          properties:
             id:
               $ref: '#/components/schemas/FileId'
             created_at:
-              format: date-time
               description: The instant at which the file was first created in the 3scale CMS
               type: string
-            updated_at:
               format: date-time
+            updated_at:
               description: The instant at which the file was last updated
               type: string
+              format: date-time
             url:
               description: The location at which the file is stored by 3scale; for 3scale-internal use
               type: string
@@ -516,7 +520,6 @@ components:
           section_id: 33
           path: /images/desk.jpg
           url: http://s3.openshift-storage.svc/bucket--99173774-11c4-4a63-9d1a-2df7b6a0b5bd/provider-name/2022/03/05/desk-b2a6c318d66334d2.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=VLXdr0R4TkaRNkgubbLx%2F20221005%2Fus-east-1%2Fs3%2Faws4_request&amp;X-Amz-Date=20221005T214121Z&amp;X-Amz-Expires=900&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Signature=aa05d76d599d07c6e8593a92edbe2d261aa6990326864d39465430b25761275e
-          tag_list: ''
           title: desk.jpg
         - id: 10
           created_at: 2022-03-05T04:48:28Z
@@ -524,10 +527,10 @@ components:
           section_id: 33
           path: /images/mouse.jpg
           url: http://s3.openshift-storage.svc/bucket--99173774-11c4-4a63-9d1a-2df7b6a0b5bd/provider-name/2022/03/05/mouse-54d77f30bdfb31a4.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=VLXdr0R4TkaRNkgubbLx%2F20221005%2Fus-east-1%2Fs3%2Faws4_request&amp;X-Amz-Date=20221005T214121Z&amp;X-Amz-Expires=900&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Signature=186eab31325093ec6b542ff9805621e6c1fa9a26bdfce24f7f9e446f22e635ca
-          tag_list: ''
           title: mouse.jpg
     FileUpdatableFields:
       description: Fields that may be modified after file creation
+      type: object
       properties:
         section_id:
           $ref: '#/components/schemas/SectionId'
@@ -537,9 +540,6 @@ components:
             Portal. Must be unique across all CMS objects
           type: string
           maxLength: 255
-        tag_list:
-          description: Comma-separated list of tags
-          type: string
         downloadable:
           description: |
             Flag indicating whether the file will be returned from the Developer
@@ -556,7 +556,8 @@ components:
     Layout:
       allOf:
         - $ref: '#/components/schemas/Template'
-        - properties:
+        - type: object
+          properties:
             system_name:
               $ref: '#/components/schemas/SystemName'
             title:
@@ -589,7 +590,8 @@ components:
     Page:
       allOf:
         - $ref: '#/components/schemas/Template'
-        - properties:
+        - type: object
+          properties:
             path:
               description: |
                 The path to which this template will be retrieved when browsing
@@ -620,7 +622,8 @@ components:
     Partial:
       allOf:
         - $ref: '#/components/schemas/Template'
-        - properties:
+        - type: object
+          properties:
             system_name:
               $ref: '#/components/schemas/SystemName'
       example:
@@ -734,7 +737,8 @@ components:
       description: Section within 3scale CMS
       allOf:
         - $ref: '#/components/schemas/SectionUpdatableFields'
-        - properties:
+        - type: object
+          properties:
             id:
               $ref: '#/components/schemas/SectionId'
             created_at:
@@ -761,7 +765,8 @@ components:
       description: Request fields for creation of Sections
       allOf:
         - $ref: '#/components/schemas/SectionUpdatableFields'
-        - properties:
+        - type: object
+          properties:
             partial_path:
               type: string
               maxLength: 255
@@ -828,6 +833,7 @@ components:
             partial_path: /password
     SectionUpdatableFields:
       description: Fields that may be modified after section creation
+      type: object
       properties:
         public:
           description: Whether the section is viewable by users not logged in
@@ -845,6 +851,7 @@ components:
       maxLength: 255
     Template:
       description: Base type for all template types
+      type: object
       discriminator:
         propertyName: type
         mapping:
@@ -857,11 +864,11 @@ components:
         id:
           $ref: '#/components/schemas/TemplateId'
         created_at:
-          format: date-time
           type: string
+          format: date-time
         updated_at:
-          format: date-time
           type: string
+          format: date-time
         content_type:
           description: |
             How the template should be described to web browsers with the
@@ -886,6 +893,7 @@ components:
           type: string
           maxLength: 16777215
     TemplateCreationRequest:
+      type: object
       required:
         - type
       allOf:
@@ -946,6 +954,7 @@ components:
           total_pages: 4
           current_page: 1
     TemplateUpdatableFields:
+      type: object
       properties:
         system_name:
           $ref: '#/components/schemas/SystemName'
@@ -1018,36 +1027,40 @@ components:
   responses:
     EmptyResponse:
       description: Response with no body; eg, to indicate successful deletion
-    ErrorHashResponse:
-      content:
-        application/xml:
-          schema:
-            $ref: '#/components/schemas/ErrorHash'
-      description: Response containing an `ErrorHash`
-    ErrorListResponse:
+    ErrorResponse:
+      description: Response containing an `Error`
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorList'
-      description: Response containing an `ErrorList`
+            $ref: '#/components/schemas/Error'
+          examples:
+            server_error:
+              description: Internal Server Error
+              value:
+                status: 500
+                error: Internal Server Error
+            builtin_delete:
+              description: Built-in resource deletion error
+              value:
+                error: Built-in resources can't be deleted
     FileResponse:
+      description: Response containing a single file declaration
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/File'
-      description: Response containing a single file declaration
     FileListResponse:
+      description: Response containing a list of `File`s
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/FileList'
-      description: Response containing a list of `File`s
     ProviderAccountResponse:
+      description: Response containing the `WrappedProviderAccount` configuration
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/WrappedProviderAccount'
-      description: Response containing the `WrappedProviderAccount` configuration
     SectionListResponse:
       content:
         application/json:
@@ -1074,20 +1087,20 @@ components:
       description: Response containing a single `Section`
   securitySchemes:
     provider_key:
-      type: apiKey
       description: >-
         Provider API Key from the `Account Settings > Overview` page of a 3scale tenant.
         To view this key, a user must be logged in with `admin` privileges.
-      name: provider_key
-      in: query
-    access_token:
       type: apiKey
+      in: query
+      name: provider_key
+    access_token:
       description: >-
         Access Token from the `Account Settings > Personal > Tokens` page of a 3scale tenant.
         The token must have access to both the `Account Management API` and the
         `Developer Portal API`.
-      name: access_token
+      type: apiKey
       in: query
+      name: access_token
 security:
   - provider_key: [ ]
   - access_token: [ ]

--- a/rest-client/src/test/java/com/fwmotion/threescale/cms/ThreescaleCmsClientImplUnitTest.java
+++ b/rest-client/src/test/java/com/fwmotion/threescale/cms/ThreescaleCmsClientImplUnitTest.java
@@ -1,5 +1,7 @@
 package com.fwmotion.threescale.cms;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fwmotion.threescale.cms.mixins.EnumHandlerMixIn;
 import com.fwmotion.threescale.cms.model.*;
 import com.fwmotion.threescale.cms.testsupport.FilesApiTestSupport;
 import com.fwmotion.threescale.cms.testsupport.SectionsApiTestSupport;
@@ -8,10 +10,7 @@ import com.redhat.threescale.rest.cms.ApiClient;
 import com.redhat.threescale.rest.cms.api.FilesApi;
 import com.redhat.threescale.rest.cms.api.SectionsApi;
 import com.redhat.threescale.rest.cms.api.TemplatesApi;
-import com.redhat.threescale.rest.cms.model.ModelFile;
-import com.redhat.threescale.rest.cms.model.ProviderAccount;
-import com.redhat.threescale.rest.cms.model.Section;
-import com.redhat.threescale.rest.cms.model.WrappedProviderAccount;
+import com.redhat.threescale.rest.cms.model.*;
 import org.apache.commons.io.IOUtils;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -34,7 +33,6 @@ import java.nio.charset.Charset;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.fwmotion.threescale.cms.matchers.HeaderMatcher.header;
@@ -60,6 +58,8 @@ class ThreescaleCmsClientImplUnitTest {
     SectionsApi sectionsApi;
     @Mock
     TemplatesApi templatesApi;
+    @Spy
+    ObjectMapper objectMapper = new ObjectMapper();
 
     SectionsApiTestSupport sectionsApiTestSupport;
     FilesApiTestSupport filesApiTestSupport;
@@ -78,6 +78,8 @@ class ThreescaleCmsClientImplUnitTest {
 
     @BeforeEach
     void setUp() {
+        objectMapper.addMixIn(EnumHandler.class, EnumHandlerMixIn.class);
+
         sectionsApiTestSupport = new SectionsApiTestSupport(sectionsApi);
         filesApiTestSupport = new FilesApiTestSupport(filesApi);
         templatesApiTestSupport = new TemplatesApiTestSupport(templatesApi);
@@ -694,13 +696,7 @@ class ThreescaleCmsClientImplUnitTest {
         newFile.setId(null);
         newFile.setPath("/file.jpg");
         newFile.setSectionId(30L);
-        newFile.setTags(Set.of("a", "b", "c"));
         newFile.setDownloadable(true);
-
-        String expectedTagString = newFile.getTags()
-            .stream()
-            .sorted()
-            .collect(Collectors.joining(","));
 
         // And a File
         File newFileContent = new File("/tmp/file.jpg");
@@ -710,7 +706,6 @@ class ThreescaleCmsClientImplUnitTest {
             eq(newFile.getSectionId()),
             eq(newFile.getPath()),
             same(newFileContent),
-            eq(expectedTagString),
             eq(newFile.getDownloadable()),
             nullable(String.class)))
             .willReturn(new ModelFile()
@@ -725,7 +720,6 @@ class ThreescaleCmsClientImplUnitTest {
             eq(newFile.getSectionId()),
             eq(newFile.getPath()),
             same(newFileContent),
-            eq(expectedTagString),
             eq(newFile.getDownloadable()),
             nullable(String.class));
         then(sectionsApi).shouldHaveNoInteractions();
@@ -742,13 +736,7 @@ class ThreescaleCmsClientImplUnitTest {
         updateFile.setId(16L);
         updateFile.setPath("/file.jpg");
         updateFile.setSectionId(30L);
-        updateFile.setTags(Set.of("a", "b", "c"));
         updateFile.setDownloadable(true);
-
-        String expectedTagString = updateFile.getTags()
-            .stream()
-            .sorted()
-            .collect(Collectors.joining(","));
 
         // And a File
         File newFileContent = new File("/tmp/file.jpg");
@@ -758,7 +746,6 @@ class ThreescaleCmsClientImplUnitTest {
             eq(updateFile.getId()),
             eq(updateFile.getSectionId()),
             eq(updateFile.getPath()),
-            eq(expectedTagString),
             eq(updateFile.getDownloadable()),
             same(newFileContent),
             nullable(String.class)))
@@ -774,7 +761,6 @@ class ThreescaleCmsClientImplUnitTest {
             eq(updateFile.getId()),
             eq(updateFile.getSectionId()),
             eq(updateFile.getPath()),
-            eq(expectedTagString),
             eq(updateFile.getDownloadable()),
             same(newFileContent),
             nullable(String.class));
@@ -805,7 +791,6 @@ class ThreescaleCmsClientImplUnitTest {
         newFile.setId(16L);
         newFile.setPath("/file.jpg");
         newFile.setSectionId(30L);
-        newFile.setTags(Set.of("a", "b", "c"));
         newFile.setDownloadable(true);
 
         // When the interface code is called

--- a/rest-client/src/test/java/com/fwmotion/threescale/cms/matchers/CmsFileMatcher.java
+++ b/rest-client/src/test/java/com/fwmotion/threescale/cms/matchers/CmsFileMatcher.java
@@ -27,8 +27,7 @@ public class CmsFileMatcher extends CmsObjectMatcher {
 
         return super.matchesSafely(actual)
             && actualMatchesExpected(expected.getSectionId(), actualFile.getSectionId())
-            && actualMatchesExpected(expected.getPath(), actualFile.getPath())
-            && actualMatchesExpected(expected.getTagList(), String.join(",", actualFile.getTags()));
+            && actualMatchesExpected(expected.getPath(), actualFile.getPath());
     }
 
     @Override

--- a/rest-client/src/test/java/com/fwmotion/threescale/cms/testsupport/FilesApiTestSupport.java
+++ b/rest-client/src/test/java/com/fwmotion/threescale/cms/testsupport/FilesApiTestSupport.java
@@ -25,7 +25,6 @@ public class FilesApiTestSupport {
         .sectionId(2675715L)
         .path("/favicon.ico")
         .url("http://s3.openshift-storage.svc/bucket--99173774-11c4-4a63-9d1a-2df7b6a0b5bd/provider-name/2022/03/05/favicon-e94f1a378c59231c.ico?X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=VLXdr0R4TkaRNkgubbLx%2F20221005%2Fus-east-1%2Fs3%2Faws4_request&amp;X-Amz-Date=20221005T214121Z&amp;X-Amz-Expires=900&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Signature=deb0c4a3741a76adf739c3865c978aa0a062410685efa0b16e2827c977ea3143")
-        .tagList("")
         .title("favicon.ico")
         .createdAt(OffsetDateTime.of(2022, 3, 5, 4, 48, 29, 0, ZoneOffset.UTC))
         .updatedAt(OffsetDateTime.of(2022, 3, 5, 4, 48, 29, 0, ZoneOffset.UTC));

--- a/samples/tekton/task-3scale-cms-copy.yaml
+++ b/samples/tekton/task-3scale-cms-copy.yaml
@@ -104,7 +104,7 @@ spec:
       for downloading CMS content. The information should include data such as
       the Admin Portal base URL and either a Provider Key or a Personal Access
       Token. (Note that when a Personal Access Token is used, it must have
-      permission to the Content Management API. Binding a Secret to this
+      permission to the Developer Portal API. Binding a Secret to this
       Workspace is strongly recommended over other volume types.
   - name: target-provider-details
     description: >-
@@ -112,5 +112,5 @@ spec:
       for uploading CMS content. The information should include data such as
       the Admin Portal base URL and either a Provider Key or a Personal Access
       Token. (Note that when a Personal Access Token is used, it must have
-      permission to the Content Management API. Binding a Secret to this
+      permission to the Developer Portal API. Binding a Secret to this
       Workspace is strongly recommended over other volume types.

--- a/samples/tekton/task-3scale-cms.yaml
+++ b/samples/tekton/task-3scale-cms.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 3scale-cms
 spec:
   description: >-
-    3scale-cms task to interact with the 3scale Content Management API
+    3scale-cms task to interact with the 3scale Developer Portal API
   params:
   - name: 3scale-cms-image
     type: string
@@ -83,6 +83,6 @@ spec:
       A Workspace containing the information required to interact with 3scale,
       such as the Admin Portal base URL and either a Provider Key or a
       Personal Access Token. (Note that when a Personal Access Token is used,
-      it must have permission to the Content Management API. Binding a Secret
+      it must have permission to the Developer Portal API. Binding a Secret
       to this Workspace is strongly recommended over other volume types.
 


### PR DESCRIPTION
* Do not send empty layout ("") for new pages
* Use application/x-www-form-urlencoded for template create requests
* Do not handle tag_list on files as it's not part of the API anymore
* Add an Exception hierarchy
* Refer to the API using its official name Developer Portal API instead of Content Management API
* Remove distinction between ErrorHash and plain Error objects in OpenAPI doc

Resolves FwMotion#99
Resolves FwMotion#16